### PR TITLE
fix: do not insert `[tool.uv]` if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* Do not insert `[tool.uv]` if empty ([#17](https://github.com/mkniewallner/migrate-to-uv/pull/17))
+
 ## 0.1.1 - 2024-12-26
 
 ### Miscellaneous
 
-- Fix documentation publishing and package metadata
+* Fix documentation publishing and package metadata ([#3](https://github.com/mkniewallner/migrate-to-uv/pull/3))
 
 ## 0.1.0 - 2024-12-26
 

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/full/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/full/pyproject.toml\"),\nDependencyGroupsStrategy::SetDefaultGroups,)"
 snapshot_kind: text
 ---

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_dep_group_include_in_dev.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_dep_group_include_in_dev.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/full/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/full/pyproject.toml\"),\nDependencyGroupsStrategy::IncludeInDev,)"
 snapshot_kind: text
 ---

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_dep_group_keep_existing.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_dep_group_keep_existing.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/full/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/full/pyproject.toml\"),\nDependencyGroupsStrategy::KeepExisting,)"
 snapshot_kind: text
 ---

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_dep_group_merge_in_dev.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_dep_group_merge_in_dev.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/full/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/full/pyproject.toml\"),\nDependencyGroupsStrategy::MergeIntoDev,)"
 snapshot_kind: text
 ---

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_empty_requires.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_empty_requires.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/empty_requires/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/empty_requires/pyproject.toml\"),\nDependencyGroupsStrategy::SetDefaultGroups,)"
 snapshot_kind: text
 ---

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_minimal_pipfile.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_minimal_pipfile.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/minimal/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/minimal/pyproject.toml\"),\nDependencyGroupsStrategy::SetDefaultGroups,)"
 snapshot_kind: text
 ---

--- a/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_python_full_version.snap
+++ b/src/converters/pipenv/snapshots/migrate_to_uv__converters__pipenv__tests__perform_migration_python_full_version.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/pipenv/mod.rs
+source: src/converters/pipenv/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/pipenv/python_full_version/Pipfile\"),\nPath::new(\"tests/fixtures/pipenv/python_full_version/pyproject.toml\"),\nDependencyGroupsStrategy::SetDefaultGroups,)"
 snapshot_kind: text
 ---

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_minimal_pyproject.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_minimal_pyproject.snap
@@ -1,6 +1,6 @@
 ---
-source: src/migrators/poetry/mod.rs
-expression: "perform_migration(Path::new(\"tests/fixtures/poetry/minimal/pyproject.toml\"),\nfalse, DependencyGroupsStrategy::IncludeInDev,)"
+source: src/converters/poetry/mod.rs
+expression: "perform_migration(Path::new(\"tests/fixtures/poetry/minimal/pyproject.toml\"),\nfalse, DependencyGroupsStrategy::SetDefaultGroups,)"
 snapshot_kind: text
 ---
 '''
@@ -10,8 +10,6 @@ version = "0.0.1"
 
 [tool.ruff]
 fix = true
-
-[tool.uv]
 
 [tool.ruff.format]
 preview = true

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_multiple_readmes.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_multiple_readmes.snap
@@ -1,5 +1,5 @@
 ---
-source: src/migrators/poetry/mod.rs
+source: src/converters/poetry/mod.rs
 expression: "perform_migration(Path::new(\"tests/fixtures/poetry/multiple_readmes/pyproject.toml\"),\nfalse, DependencyGroupsStrategy::SetDefaultGroups,)"
 snapshot_kind: text
 ---
@@ -8,6 +8,4 @@ snapshot_kind: text
 name = ""
 version = "0.0.1"
 readme = "README1.md"
-
-[tool.uv]
 '''

--- a/src/converters/pyproject_updater.rs
+++ b/src/converters/pyproject_updater.rs
@@ -45,6 +45,10 @@ impl PyprojectUpdater<'_> {
 
     /// Adds or replaces uv-specific data in TOML document.
     pub fn insert_uv(&mut self, uv: &Uv) {
+        if uv == &Uv::default() {
+            return;
+        }
+
         if !self.pyproject.contains_key("tool") {
             self.pyproject["tool"] = table();
         }

--- a/src/schema/uv.rs
+++ b/src/schema/uv.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Uv {
     pub package: Option<bool>,
     /// <https://docs.astral.sh/uv/configuration/indexes/#defining-an-index>
@@ -13,7 +13,7 @@ pub struct Uv {
     pub default_groups: Option<Vec<String>>,
 }
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Index {
     pub name: String,
     pub url: Option<String>,
@@ -21,7 +21,7 @@ pub struct Index {
     pub explicit: Option<bool>,
 }
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize, Eq, PartialEq)]
 pub struct SourceIndex {
     pub index: Option<String>,
     pub path: Option<String>,
@@ -35,7 +35,7 @@ pub struct SourceIndex {
     pub marker: Option<String>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum SourceContainer {
     SourceIndex(SourceIndex),


### PR DESCRIPTION
Right now, if all values in `Uv` structure are set to `None`, a `[tool.uv]` section is inserted, e.g.:

```toml
[tool.uv]

[tool.ruff]
fix = true
```

In this case, the section should not be added.