### PR TITLE
fix(poetry): avoid crash when extra lists non-existing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* [poetry] Avoid crashing when an extra lists a non-existing dependency ([#30](https://github.com/mkniewallner/migrate-to-uv/pull/30))
+
 ## 0.2.0 - 2025-01-05
 
 ### Features

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration.snap
@@ -99,6 +99,7 @@ extra-2 = [
     "dep-in-extra==1.2.3",
     "optional-in-extra==1.2.3",
 ]
+extra-with-non-existing-dependencies = []
 
 [project.urls]
 Homepage = "https://homepage.example.com"

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_include_in_dev.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_include_in_dev.snap
@@ -99,6 +99,7 @@ extra-2 = [
     "dep-in-extra==1.2.3",
     "optional-in-extra==1.2.3",
 ]
+extra-with-non-existing-dependencies = []
 
 [project.urls]
 Homepage = "https://homepage.example.com"

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_keep_existing.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_keep_existing.snap
@@ -99,6 +99,7 @@ extra-2 = [
     "dep-in-extra==1.2.3",
     "optional-in-extra==1.2.3",
 ]
+extra-with-non-existing-dependencies = []
 
 [project.urls]
 Homepage = "https://homepage.example.com"

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_merge_in_dev.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_merge_in_dev.snap
@@ -99,6 +99,7 @@ extra-2 = [
     "dep-in-extra==1.2.3",
     "optional-in-extra==1.2.3",
 ]
+extra-with-non-existing-dependencies = []
 
 [project.urls]
 Homepage = "https://homepage.example.com"

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_keep_old_metadata.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_keep_old_metadata.snap
@@ -99,6 +99,7 @@ extra-2 = [
     "dep-in-extra==1.2.3",
     "optional-in-extra==1.2.3",
 ]
+extra-with-non-existing-dependencies = []
 
 [project.urls]
 Homepage = "https://homepage.example.com"
@@ -411,6 +412,7 @@ packages-glob-to = "to/packages-glob-to"
 [tool.poetry.extras]
 extra = ["dep-in-extra"]
 extra-2 = ["dep-in-extra", "optional-in-extra"]
+extra-with-non-existing-dependencies = ["non-existing-dependency"]
 
 [tool.poetry.dev-dependencies]
 dev-legacy = "1.2.3"

--- a/tests/fixtures/poetry/full/pyproject.toml
+++ b/tests/fixtures/poetry/full/pyproject.toml
@@ -168,6 +168,7 @@ multiple-constraints-python-platform-markers-source  = [
 [tool.poetry.extras]
 extra = ["dep-in-extra"]
 extra-2 = ["dep-in-extra", "optional-in-extra"]
+extra-with-non-existing-dependencies = ["non-existing-dependency"]
 
 [tool.poetry.dev-dependencies]
 dev-legacy = "1.2.3"


### PR DESCRIPTION
`migrate-to-uv` currently panics when migrating to `[project.optional-dependencies]` an extra in `[tool.poetry.extras]` that lists a dependency that is not in the dependencies.

Additionally to handling this case, warn the user that the dependency was not found for the extra.