### PR TITLE
chore: bump rust to 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "migrate-to-uv"
 version = "0.2.1"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.84"
 license = "MIT"
 authors = ["Mathieu Kniewallner <mathieu.kniewallner@gmail.com>"]
 default-run = "migrate-to-uv"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83"
+channel = "1.84"


### PR DESCRIPTION
https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html