### PR TITLE
feat: lock dependencies at the end of migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+Dependencies are now locked with `uv lock` at the end of the migration, if `uv` is detected as an executable. This new
+behavior can be opted out by setting `--skip-lock` flag, like so:
+
+```bash
+migrate-to-uv --skip-lock
+```
+
+### Features
+
+* Lock dependencies at the end of migration ([#46](https://github.com/mkniewallner/migrate-to-uv/pull/46))
+
 ## 0.2.1 - 2025-01-05
 
 ### Bug fixes

--- a/docs/usage-and-configuration.md
+++ b/docs/usage-and-configuration.md
@@ -42,6 +42,17 @@ the terminal.
 migrate-to-uv --dry-run
 ```
 
+#### `--skip-lock`
+
+By default, `migrate-to-uv` locks dependencies with `uv lock` at the end of the migration. This flag disables this
+behavior.
+
+**Example**:
+
+```bash
+migrate-to-uv --skip-lock
+```
+
 #### `--package-manager`
 
 By default, `migrate-to-uv` tries to auto-detect the package manager based on the files (and their content) used by the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,11 @@ struct Cli {
     dry_run: bool,
     #[arg(
         long,
+        help = "Do not lock dependencies with uv at the end of the migration"
+    )]
+    skip_lock: bool,
+    #[arg(
+        long,
         help = "Enforce a specific package manager instead of auto-detecting it"
     )]
     package_manager: Option<PackageManager>,
@@ -66,6 +71,7 @@ pub fn cli() {
         Ok(converter) => {
             converter.convert_to_uv(
                 cli.dry_run,
+                cli.skip_lock,
                 cli.keep_current_data,
                 cli.dependency_groups_strategy,
             );

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,8 +1,13 @@
 use crate::schema::pyproject::DependencyGroupSpecification;
 use indexmap::IndexMap;
+use log::{error, info, warn};
+use owo_colors::OwoColorize;
 #[cfg(test)]
 use std::any::Any;
 use std::fmt::Debug;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::process::{Command, Stdio};
 
 pub mod pip;
 pub mod pipenv;
@@ -19,12 +24,68 @@ pub trait Converter: Debug {
     fn convert_to_uv(
         &self,
         dry_run: bool,
+        skip_lock: bool,
         keep_old_metadata: bool,
         dependency_groups_strategy: DependencyGroupsStrategy,
     );
 
     #[cfg(test)]
     fn as_any(&self) -> &dyn Any;
+}
+
+pub fn lock_dependencies(project_path: &Path) -> Result<(), ()> {
+    const UV_EXECUTABLE: &str = "uv";
+
+    match Command::new(UV_EXECUTABLE)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(_) => {
+            info!(
+                "Locking dependencies with \"{}\"...",
+                format!("{UV_EXECUTABLE} lock").bold()
+            );
+
+            Command::new(UV_EXECUTABLE)
+                .arg("lock")
+                .current_dir(project_path)
+                .spawn()
+                .map_or_else(
+                    |_| {
+                        error!(
+                            "Could not invoke \"{}\" command.",
+                            format!("{UV_EXECUTABLE} lock").bold()
+                        );
+                        Err(())
+                    },
+                    |lock| match lock.wait_with_output() {
+                        Ok(output) => {
+                            if output.status.success() {
+                                Ok(())
+                            } else {
+                                Err(())
+                            }
+                        }
+                        Err(e) => {
+                            error!("{e}");
+                            Err(())
+                        }
+                    },
+                )
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            warn!(
+                "Could not find \"{}\" executable, skipping locking dependencies.",
+                UV_EXECUTABLE.bold()
+            );
+            Ok(())
+        }
+        Err(e) => {
+            error!("{e}");
+            Err(())
+        }
+    }
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -6,14 +6,14 @@ pub mod version;
 
 use crate::converters::poetry::build_backend::get_hatch;
 use crate::converters::pyproject_updater::PyprojectUpdater;
-use crate::converters::Converter;
 use crate::converters::DependencyGroupsStrategy;
+use crate::converters::{lock_dependencies, Converter};
 use crate::schema::pep_621::Project;
 use crate::schema::pyproject::PyProject;
 use crate::schema::uv::{SourceContainer, Uv};
 use crate::toml::PyprojectPrettyFormatter;
 use indexmap::IndexMap;
-use log::info;
+use log::{info, warn};
 use owo_colors::OwoColorize;
 #[cfg(test)]
 use std::any::Any;
@@ -33,6 +33,7 @@ impl Converter for Poetry {
     fn convert_to_uv(
         &self,
         dry_run: bool,
+        skip_lock: bool,
         keep_old_metadata: bool,
         dependency_groups_strategy: DependencyGroupsStrategy,
     ) {
@@ -58,6 +59,11 @@ impl Converter for Poetry {
 
             if !keep_old_metadata {
                 delete_poetry_references(&self.project_path).unwrap();
+            }
+
+            if !dry_run && !skip_lock && lock_dependencies(self.project_path.as_ref()).is_err() {
+                warn!("Project migrated from Poetry to uv, but an error occurred when locking dependencies.");
+                return;
             }
 
             info!(

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration.snap
@@ -166,8 +166,8 @@ default = true
 with-source = { index = "supplemental" }
 python-restricted-with-source = { index = "supplemental" }
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", editable = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", editable = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", editable = false }
+local-package-editable = { path = "editable-package/", editable = true }
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }
 git = { git = "https://example.com/foo/bar" }
 git-branch = { git = "https://example.com/foo/bar", branch = "foo" }

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_include_in_dev.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_include_in_dev.snap
@@ -163,8 +163,8 @@ default = true
 with-source = { index = "supplemental" }
 python-restricted-with-source = { index = "supplemental" }
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", editable = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", editable = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", editable = false }
+local-package-editable = { path = "editable-package/", editable = true }
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }
 git = { git = "https://example.com/foo/bar" }
 git-branch = { git = "https://example.com/foo/bar", branch = "foo" }

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_keep_existing.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_keep_existing.snap
@@ -162,8 +162,8 @@ default = true
 with-source = { index = "supplemental" }
 python-restricted-with-source = { index = "supplemental" }
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", editable = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", editable = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", editable = false }
+local-package-editable = { path = "editable-package/", editable = true }
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }
 git = { git = "https://example.com/foo/bar" }
 git-branch = { git = "https://example.com/foo/bar", branch = "foo" }

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_merge_in_dev.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_dep_group_merge_in_dev.snap
@@ -162,8 +162,8 @@ default = true
 with-source = { index = "supplemental" }
 python-restricted-with-source = { index = "supplemental" }
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", editable = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", editable = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", editable = false }
+local-package-editable = { path = "editable-package/", editable = true }
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }
 git = { git = "https://example.com/foo/bar" }
 git-branch = { git = "https://example.com/foo/bar", branch = "foo" }

--- a/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_keep_old_metadata.snap
+++ b/src/converters/poetry/snapshots/migrate_to_uv__converters__poetry__tests__perform_migration_keep_old_metadata.snap
@@ -222,8 +222,8 @@ default = true
 with-source = { index = "supplemental" }
 python-restricted-with-source = { index = "supplemental" }
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", editable = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", editable = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", editable = false }
+local-package-editable = { path = "editable-package/", editable = true }
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }
 git = { git = "https://example.com/foo/bar" }
 git-branch = { git = "https://example.com/foo/bar", branch = "foo" }
@@ -307,8 +307,8 @@ optional-not-in-extra = { version = "1.2.3", optional = true }
 
 # Path
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", develop = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", develop = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", develop = false }
+local-package-editable = { path = "editable-package/", develop = true }
 
 # URL
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }

--- a/tests/fixtures/poetry/full/pyproject.toml
+++ b/tests/fixtures/poetry/full/pyproject.toml
@@ -118,8 +118,8 @@ optional-not-in-extra = { version = "1.2.3", optional = true }
 
 # Path
 local-package = { path = "package/" }
-local-package-2 = { path = "another-package/", develop = false }
-local-package-editable = { path = "package/dist/package-0.1.0.tar.gz", develop = true }
+local-package-2 = { path = "package/dist/package-0.1.0.tar.gz", develop = false }
+local-package-editable = { path = "editable-package/", develop = true }
 
 # URL
 url-dep = { url = "https://example.com/package-0.0.1.tar.gz" }


### PR DESCRIPTION
Closes #40.

Run `uv lock` at the end of the migration process, but make it possible to skip this new behaviour with `--skip-lock`.