### PR TITLE
fix(pip): do not constrain dependencies

### DIFF
--- a/src/converters/pip/dependencies.rs
+++ b/src/converters/pip/dependencies.rs
@@ -28,11 +28,12 @@ pub fn get(project_path: &Path, requirements_files: Vec<String>) -> Option<Vec<S
 
 pub fn get_constraint_dependencies(
     ignore_locked_versions: bool,
+    is_pip_tools: bool,
     project_path: &Path,
     requirements_files: Vec<String>,
     dev_requirements_files: Vec<String>,
 ) -> Option<Vec<String>> {
-    if ignore_locked_versions {
+    if !is_pip_tools || ignore_locked_versions {
         return None;
     }
 

--- a/src/converters/pip/mod.rs
+++ b/src/converters/pip/mod.rs
@@ -73,7 +73,9 @@ impl Converter for Pip {
                 );
             }
 
-            if !ignore_locked_versions {
+            // There are no locked dependencies for pip, so we only have to remove constraints for
+            // pip-tools.
+            if self.is_pip_tools && !ignore_locked_versions {
                 let mut pyproject_updater = PyprojectUpdater {
                     pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
                 };
@@ -151,6 +153,7 @@ impl Pip {
             package: Some(false),
             constraint_dependencies: get_constraint_dependencies(
                 ignore_locked_versions,
+                self.is_pip_tools,
                 &self.project_path,
                 self.requirements_files.clone(),
                 self.dev_requirements_files.clone(),


### PR DESCRIPTION
pip does not have lock files, only pip-tools does, so no need to add/remove `constraint-dependencies` and lock twice for pip.