### PR TITLE
feat(pipenv): delete `Pipfile.lock` after migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+* [poetry] Delete `poetry.toml` after migration ([#62](https://github.com/mkniewallner/migrate-to-uv/pull/62))
+* [pipenv] Delete `Pipfile.lock` after migration ([#66](https://github.com/mkniewallner/migrate-to-uv/pull/66))
+
 ### Documentation
 
 * Explain how to set credentials for private indexes ([#60](https://github.com/mkniewallner/migrate-to-uv/pull/60))

--- a/src/converters/pipenv/mod.rs
+++ b/src/converters/pipenv/mod.rs
@@ -23,6 +23,8 @@ use std::path::PathBuf;
 use toml_edit::visit_mut::VisitMut;
 use toml_edit::DocumentMut;
 
+const FILES_TO_DELETE: &[&str] = &["Pipfile", "Pipfile.lock"];
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Pipenv {
     pub project_path: PathBuf,
@@ -171,10 +173,12 @@ impl Pipenv {
     }
 
     fn delete_pipenv_references(&self) -> std::io::Result<()> {
-        let pipfile_path = self.project_path.join("Pipfile");
+        for file in FILES_TO_DELETE {
+            let path = self.project_path.join(file);
 
-        if pipfile_path.exists() {
-            remove_file(pipfile_path)?;
+            if path.exists() {
+                remove_file(path)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Spotted in https://github.com/mkniewallner/migrate-to-uv/pull/64.