### PR TITLE
refactor(converters): reduce code duplication

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::converters::DependencyGroupsStrategy;
+use crate::converters::{ConverterOptions, DependencyGroupsStrategy};
 use crate::detector::{get_converter, PackageManager};
 use crate::logger;
 use clap::builder::styling::{AnsiColor, Effects};
@@ -67,20 +67,23 @@ pub fn cli() {
 
     logger::configure(cli.verbose);
 
+    let converter_options = ConverterOptions {
+        project_path: PathBuf::from(&cli.path),
+        dry_run: cli.dry_run,
+        skip_lock: cli.skip_lock,
+        ignore_locked_versions: cli.ignore_locked_versions,
+        keep_old_metadata: cli.keep_current_data,
+        dependency_groups_strategy: cli.dependency_groups_strategy,
+    };
+
     match get_converter(
-        &cli.path,
+        &converter_options,
         cli.requirements_file,
         cli.dev_requirements_file,
         cli.package_manager,
     ) {
         Ok(converter) => {
-            converter.convert_to_uv(
-                cli.dry_run,
-                cli.skip_lock,
-                cli.ignore_locked_versions,
-                cli.keep_current_data,
-                cli.dependency_groups_strategy,
-            );
+            converter.convert_to_uv();
         }
         Err(error) => {
             error!("{}", error);

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,3 +1,4 @@
+use crate::converters::pyproject_updater::PyprojectUpdater;
 use crate::schema::pyproject::DependencyGroupSpecification;
 use indexmap::IndexMap;
 use log::{error, info, warn};
@@ -5,9 +6,11 @@ use owo_colors::OwoColorize;
 #[cfg(test)]
 use std::any::Any;
 use std::fmt::Debug;
-use std::io::ErrorKind;
-use std::path::Path;
+use std::fs::{remove_file, File};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use toml_edit::DocumentMut;
 
 pub mod pip;
 pub mod pipenv;
@@ -19,22 +22,171 @@ type DependencyGroupsAndDefaultGroups = (
     Option<Vec<String>>,
 );
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ConverterOptions {
+    pub project_path: PathBuf,
+    pub dry_run: bool,
+    pub skip_lock: bool,
+    pub ignore_locked_versions: bool,
+    pub keep_old_metadata: bool,
+    pub dependency_groups_strategy: DependencyGroupsStrategy,
+}
+
 /// Converts a project from a package manager to uv.
 pub trait Converter: Debug {
-    #[allow(clippy::fn_params_excessive_bools)]
-    fn convert_to_uv(
-        &self,
-        dry_run: bool,
-        skip_lock: bool,
-        ignore_locked_versions: bool,
-        keep_old_metadata: bool,
-        dependency_groups_strategy: DependencyGroupsStrategy,
-    );
+    /// Performs the conversion from the current package manager to uv.
+    fn convert_to_uv(&self) {
+        let pyproject_path = self.get_project_path().join("pyproject.toml");
+        let updated_pyproject_string = self.perform_migration();
+
+        if self.is_dry_run() {
+            let mut pyproject_updater = PyprojectUpdater {
+                pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
+            };
+            info!(
+                "{}\n{}",
+                "Migrated pyproject.toml:".bold(),
+                pyproject_updater
+                    .remove_constraint_dependencies()
+                    .map_or(updated_pyproject_string, ToString::to_string)
+            );
+            return;
+        }
+
+        let mut pyproject_file = File::create(&pyproject_path).unwrap();
+
+        pyproject_file
+            .write_all(updated_pyproject_string.as_bytes())
+            .unwrap();
+
+        self.delete_migrated_files().unwrap();
+        self.lock_dependencies();
+        self.remove_constraint_dependencies(updated_pyproject_string);
+
+        info!(
+            "{}",
+            format!(
+                "Successfully migrated project from {} to uv!\n",
+                self.get_package_manager_name()
+            )
+            .bold()
+            .green()
+        );
+    }
+
+    /// Performs the migration by handling current package manager specifics.
+    fn perform_migration(&self) -> String;
+
+    /// Name of the current package manager.
+    fn get_package_manager_name(&self) -> String;
+
+    /// Get the options chosen by the user to perform the migration, such as the project path,
+    /// whether locking should be performed at the end of the migration, ...
+    fn get_converter_options(&self) -> &ConverterOptions;
+
+    /// Path to the project to migrate.
+    fn get_project_path(&self) -> PathBuf {
+        self.get_converter_options().clone().project_path
+    }
+
+    /// Whether to perform the migration in dry-run mode, meaning that the changes are printed out
+    /// instead of made for real.
+    fn is_dry_run(&self) -> bool {
+        self.get_converter_options().dry_run
+    }
+
+    /// Whether to skip dependencies locking at the end of the migration.
+    fn skip_lock(&self) -> bool {
+        self.get_converter_options().skip_lock
+    }
+
+    /// Whether to keep current package manager data at the end of the migration.
+    fn keep_old_metadata(&self) -> bool {
+        self.get_converter_options().keep_old_metadata
+    }
+
+    /// Whether to keep versions locked in the current package manager (if it supports lock files)
+    /// when locking dependencies with uv.
+    fn respect_locked_versions(&self) -> bool {
+        !self.get_converter_options().ignore_locked_versions
+    }
+
+    /// Dependency groups strategy to use when writing development dependencies in dependency
+    /// groups.
+    fn get_dependency_groups_strategy(&self) -> DependencyGroupsStrategy {
+        self.get_converter_options().dependency_groups_strategy
+    }
+
+    /// List of files tied to the current package manager to delete at the end of the migration.
+    fn get_migrated_files_to_delete(&self) -> Vec<String>;
+
+    /// Delete files tied to the current package manager at the end of the migration, unless user
+    /// has chosen to keep the current package manager data.
+    fn delete_migrated_files(&self) -> std::io::Result<()> {
+        if self.keep_old_metadata() {
+            return Ok(());
+        }
+
+        for file in self.get_migrated_files_to_delete() {
+            let path = self.get_project_path().join(file);
+
+            if path.exists() {
+                remove_file(path)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Lock dependencies with uv, unless dry-run mode is enabled, or user has explicitly opted out
+    /// from locking dependencies.
+    fn lock_dependencies(&self) {
+        if !self.is_dry_run()
+            && !self.skip_lock()
+            && lock_dependencies(self.get_project_path().as_ref(), false).is_err()
+        {
+            warn!(
+                "An error occurred when locking dependencies, so \"{}\" was not created.",
+                "uv.lock".bold()
+            );
+        }
+    }
+
+    /// Remove `constraint-dependencies` from `[tool.uv]` in `pyproject.toml`, unless user has
+    /// explicitly opted out of keeping versions locked in the current package manager.
+    ///
+    /// Also lock dependencies, to remove `constraints` from `[manifest]` in lock file.
+    fn remove_constraint_dependencies(&self, updated_pyproject_toml: String) {
+        if !self.respect_locked_versions() {
+            return;
+        }
+
+        let mut pyproject_updater = PyprojectUpdater {
+            pyproject: &mut updated_pyproject_toml.parse::<DocumentMut>().unwrap(),
+        };
+        if let Some(updated_pyproject) = pyproject_updater.remove_constraint_dependencies() {
+            let mut pyproject_file =
+                File::create(self.get_project_path().join("pyproject.toml")).unwrap();
+            pyproject_file
+                .write_all(updated_pyproject.to_string().as_bytes())
+                .unwrap();
+
+            // Lock dependencies a second time, to remove constraints from lock file.
+            if !self.is_dry_run()
+                && !self.skip_lock()
+                && lock_dependencies(self.get_project_path().as_ref(), true).is_err()
+            {
+                warn!("An error occurred when locking dependencies after removing constraints.");
+            }
+        }
+    }
 
     #[cfg(test)]
     fn as_any(&self) -> &dyn Any;
 }
 
+/// Lock dependencies with uv by running `uv lock` command.
 pub fn lock_dependencies(project_path: &Path, is_removing_constraints: bool) -> Result<(), ()> {
     const UV_EXECUTABLE: &str = "uv";
 
@@ -95,7 +247,7 @@ pub fn lock_dependencies(project_path: &Path, is_removing_constraints: bool) -> 
     }
 }
 
-#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+#[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum DependencyGroupsStrategy {
     SetDefaultGroups,
     IncludeInDev,

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -38,7 +38,7 @@ pub trait Converter: Debug {
     /// Performs the conversion from the current package manager to uv.
     fn convert_to_uv(&self) {
         let pyproject_path = self.get_project_path().join("pyproject.toml");
-        let updated_pyproject_string = self.perform_migration();
+        let updated_pyproject_string = self.build_uv_pyproject();
 
         if self.is_dry_run() {
             let mut pyproject_updater = PyprojectUpdater {
@@ -75,8 +75,8 @@ pub trait Converter: Debug {
         );
     }
 
-    /// Performs the migration by handling current package manager specifics.
-    fn perform_migration(&self) -> String;
+    /// Build `pyproject.toml` for uv package manager based on current package manager data.
+    fn build_uv_pyproject(&self) -> String;
 
     /// Name of the current package manager.
     fn get_package_manager_name(&self) -> String;

--- a/src/converters/pip/mod.rs
+++ b/src/converters/pip/mod.rs
@@ -25,7 +25,7 @@ pub struct Pip {
 }
 
 impl Converter for Pip {
-    fn perform_migration(&self) -> String {
+    fn build_uv_pyproject(&self) -> String {
         let dev_dependencies = dependencies::get(
             &self.get_project_path(),
             self.dev_requirements_files.clone(),

--- a/src/converters/pipenv/mod.rs
+++ b/src/converters/pipenv/mod.rs
@@ -24,7 +24,7 @@ pub struct Pipenv {
 }
 
 impl Converter for Pipenv {
-    fn perform_migration(&self) -> String {
+    fn build_uv_pyproject(&self) -> String {
         let pipfile_content = fs::read_to_string(self.get_project_path().join("Pipfile")).unwrap();
         let pipfile: Pipfile = toml::from_str(pipfile_content.as_str()).unwrap();
 
@@ -131,7 +131,7 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(pipenv.perform_migration(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
         [project]
         name = ""
         version = "0.0.1"
@@ -163,7 +163,7 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(pipenv.perform_migration(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
         [project]
         name = ""
         version = "0.0.1"

--- a/src/converters/pipenv/mod.rs
+++ b/src/converters/pipenv/mod.rs
@@ -4,120 +4,28 @@ mod sources;
 
 use crate::converters::pipenv::dependencies::get_constraint_dependencies;
 use crate::converters::pyproject_updater::PyprojectUpdater;
-use crate::converters::DependencyGroupsStrategy;
-use crate::converters::{lock_dependencies, Converter};
+use crate::converters::Converter;
+use crate::converters::ConverterOptions;
 use crate::schema::pep_621::Project;
 use crate::schema::pipenv::Pipfile;
 use crate::schema::uv::{SourceContainer, Uv};
 use crate::toml::PyprojectPrettyFormatter;
 use indexmap::IndexMap;
-use log::{info, warn};
-use owo_colors::OwoColorize;
 #[cfg(test)]
 use std::any::Any;
 use std::default::Default;
 use std::fs;
-use std::fs::{remove_file, File};
-use std::io::Write;
-use std::path::PathBuf;
 use toml_edit::visit_mut::VisitMut;
 use toml_edit::DocumentMut;
 
-const FILES_TO_DELETE: &[&str] = &["Pipfile", "Pipfile.lock"];
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct Pipenv {
-    pub project_path: PathBuf,
+    pub converter_options: ConverterOptions,
 }
 
 impl Converter for Pipenv {
-    fn convert_to_uv(
-        &self,
-        dry_run: bool,
-        skip_lock: bool,
-        ignore_locked_versions: bool,
-        keep_old_metadata: bool,
-        dependency_groups_strategy: DependencyGroupsStrategy,
-    ) {
-        let pyproject_path = self.project_path.join("pyproject.toml");
-        let updated_pyproject_string =
-            self.perform_migration(ignore_locked_versions, dependency_groups_strategy);
-
-        if dry_run {
-            let mut pyproject_updater = PyprojectUpdater {
-                pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
-            };
-            info!(
-                "{}\n{}",
-                "Migrated pyproject.toml:".bold(),
-                pyproject_updater
-                    .remove_constraint_dependencies()
-                    .map_or(updated_pyproject_string, ToString::to_string)
-            );
-        } else {
-            let mut pyproject_file = File::create(&pyproject_path).unwrap();
-
-            pyproject_file
-                .write_all(updated_pyproject_string.as_bytes())
-                .unwrap();
-
-            if !keep_old_metadata {
-                self.delete_pipenv_references().unwrap();
-            }
-
-            if !dry_run
-                && !skip_lock
-                && lock_dependencies(self.project_path.as_ref(), false).is_err()
-            {
-                warn!(
-                    "An error occurred when locking dependencies, so \"{}\" was not created.",
-                    "uv.lock".bold()
-                );
-            }
-
-            if !ignore_locked_versions {
-                let mut pyproject_updater = PyprojectUpdater {
-                    pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
-                };
-                if let Some(updated_pyproject) = pyproject_updater.remove_constraint_dependencies()
-                {
-                    let mut pyproject_file = File::create(pyproject_path).unwrap();
-                    pyproject_file
-                        .write_all(updated_pyproject.to_string().as_bytes())
-                        .unwrap();
-
-                    // Lock dependencies a second time, to remove constraints from lock file.
-                    if !dry_run
-                        && !skip_lock
-                        && lock_dependencies(self.project_path.as_ref(), true).is_err()
-                    {
-                        warn!("An error occurred when locking dependencies after removing constraints.");
-                    }
-                }
-            }
-
-            info!(
-                "{}",
-                "Successfully migrated project from Pipenv to uv!\n"
-                    .bold()
-                    .green()
-            );
-        }
-    }
-
-    #[cfg(test)]
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
-impl Pipenv {
-    fn perform_migration(
-        &self,
-        ignore_locked_versions: bool,
-        dependency_groups_strategy: DependencyGroupsStrategy,
-    ) -> String {
-        let pipfile_content = fs::read_to_string(self.project_path.join("Pipfile")).unwrap();
+    fn perform_migration(&self) -> String {
+        let pipfile_content = fs::read_to_string(self.get_project_path().join("Pipfile")).unwrap();
         let pipfile: Pipfile = toml::from_str(pipfile_content.as_str()).unwrap();
 
         let mut uv_source_index: IndexMap<String, SourceContainer> = IndexMap::new();
@@ -125,7 +33,7 @@ impl Pipenv {
             dependencies::get_dependency_groups_and_default_groups(
                 &pipfile,
                 &mut uv_source_index,
-                dependency_groups_strategy,
+                self.get_dependency_groups_strategy(),
             );
 
         let project = Project {
@@ -148,13 +56,13 @@ impl Pipenv {
             },
             default_groups: uv_default_groups,
             constraint_dependencies: get_constraint_dependencies(
-                ignore_locked_versions,
-                &self.project_path.join("Pipfile.lock"),
+                !self.respect_locked_versions(),
+                &self.get_project_path().join("Pipfile.lock"),
             ),
         };
 
         let pyproject_toml_content =
-            fs::read_to_string(self.project_path.join("pyproject.toml")).unwrap_or_default();
+            fs::read_to_string(self.get_project_path().join("pyproject.toml")).unwrap_or_default();
         let mut updated_pyproject = pyproject_toml_content.parse::<DocumentMut>().unwrap();
         let mut pyproject_updater = PyprojectUpdater {
             pyproject: &mut updated_pyproject,
@@ -172,22 +80,31 @@ impl Pipenv {
         updated_pyproject.to_string()
     }
 
-    fn delete_pipenv_references(&self) -> std::io::Result<()> {
-        for file in FILES_TO_DELETE {
-            let path = self.project_path.join(file);
+    fn get_package_manager_name(&self) -> String {
+        "Pipenv".to_string()
+    }
 
-            if path.exists() {
-                remove_file(path)?;
-            }
-        }
+    fn get_converter_options(&self) -> &ConverterOptions {
+        &self.converter_options
+    }
 
-        Ok(())
+    fn get_migrated_files_to_delete(&self) -> Vec<String> {
+        vec!["Pipfile".to_string(), "Pipfile.lock".to_string()]
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::converters::DependencyGroupsStrategy;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     #[test]
@@ -204,10 +121,17 @@ mod tests {
         pipfile_file.write_all(pipfile_content.as_bytes()).unwrap();
 
         let pipenv = Pipenv {
-            project_path: PathBuf::from(project_path),
+            converter_options: ConverterOptions {
+                project_path: PathBuf::from(project_path),
+                dry_run: true,
+                skip_lock: true,
+                ignore_locked_versions: true,
+                keep_old_metadata: false,
+                dependency_groups_strategy: DependencyGroupsStrategy::SetDefaultGroups,
+            },
         };
 
-        insta::assert_snapshot!(pipenv.perform_migration(true, DependencyGroupsStrategy::SetDefaultGroups), @r###"
+        insta::assert_snapshot!(pipenv.perform_migration(), @r###"
         [project]
         name = ""
         version = "0.0.1"
@@ -229,10 +153,17 @@ mod tests {
         pipfile_file.write_all(pipfile_content.as_bytes()).unwrap();
 
         let pipenv = Pipenv {
-            project_path: PathBuf::from(project_path),
+            converter_options: ConverterOptions {
+                project_path: PathBuf::from(project_path),
+                dry_run: true,
+                skip_lock: true,
+                ignore_locked_versions: true,
+                keep_old_metadata: false,
+                dependency_groups_strategy: DependencyGroupsStrategy::SetDefaultGroups,
+            },
         };
 
-        insta::assert_snapshot!(pipenv.perform_migration(true, DependencyGroupsStrategy::SetDefaultGroups), @r###"
+        insta::assert_snapshot!(pipenv.perform_migration(), @r###"
         [project]
         name = ""
         version = "0.0.1"

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -26,7 +26,7 @@ pub struct Poetry {
 }
 
 impl Converter for Poetry {
-    fn perform_migration(&self) -> String {
+    fn build_uv_pyproject(&self) -> String {
         let pyproject_toml_content =
             fs::read_to_string(self.get_project_path().join("pyproject.toml")).unwrap_or_default();
         let pyproject: PyProject = toml::from_str(pyproject_toml_content.as_str()).unwrap();
@@ -191,7 +191,7 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(poetry.perform_migration(), @r###"
+        insta::assert_snapshot!(poetry.build_uv_pyproject(), @r###"
         [project]
         name = ""
         version = "0.0.1"

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -7,123 +7,28 @@ pub mod version;
 use crate::converters::poetry::build_backend::get_hatch;
 use crate::converters::poetry::dependencies::get_constraint_dependencies;
 use crate::converters::pyproject_updater::PyprojectUpdater;
-use crate::converters::DependencyGroupsStrategy;
-use crate::converters::{lock_dependencies, Converter};
+use crate::converters::Converter;
+use crate::converters::ConverterOptions;
 use crate::schema::pep_621::Project;
 use crate::schema::pyproject::PyProject;
 use crate::schema::uv::{SourceContainer, Uv};
 use crate::toml::PyprojectPrettyFormatter;
 use indexmap::IndexMap;
-use log::{info, warn};
-use owo_colors::OwoColorize;
 #[cfg(test)]
 use std::any::Any;
 use std::fs;
-use std::fs::{remove_file, File};
-use std::io::Write;
-use std::path::PathBuf;
 use toml_edit::visit_mut::VisitMut;
 use toml_edit::DocumentMut;
 
-const FILES_TO_DELETE: &[&str] = &["poetry.lock", "poetry.toml"];
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct Poetry {
-    pub project_path: PathBuf,
+    pub converter_options: ConverterOptions,
 }
 
 impl Converter for Poetry {
-    fn convert_to_uv(
-        &self,
-        dry_run: bool,
-        skip_lock: bool,
-        ignore_locked_versions: bool,
-        keep_old_metadata: bool,
-        dependency_groups_strategy: DependencyGroupsStrategy,
-    ) {
-        let pyproject_path = self.project_path.join("pyproject.toml");
-        let updated_pyproject_string = self.perform_migration(
-            ignore_locked_versions,
-            keep_old_metadata,
-            dependency_groups_strategy,
-        );
-
-        if dry_run {
-            let mut pyproject_updater = PyprojectUpdater {
-                pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
-            };
-            info!(
-                "{}\n{}",
-                "Migrated pyproject.toml:".bold(),
-                pyproject_updater
-                    .remove_constraint_dependencies()
-                    .map_or(updated_pyproject_string, ToString::to_string)
-            );
-            return;
-        }
-
-        let mut pyproject_file = File::create(&pyproject_path).unwrap();
-
-        pyproject_file
-            .write_all(updated_pyproject_string.as_bytes())
-            .unwrap();
-
-        if !keep_old_metadata {
-            self.delete_poetry_references().unwrap();
-        }
-
-        if !dry_run && !skip_lock && lock_dependencies(self.project_path.as_ref(), false).is_err() {
-            warn!(
-                "An error occurred when locking dependencies, so \"{}\" was not created.",
-                "uv.lock".bold()
-            );
-        }
-
-        if !ignore_locked_versions {
-            let mut pyproject_updater = PyprojectUpdater {
-                pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
-            };
-            if let Some(updated_pyproject) = pyproject_updater.remove_constraint_dependencies() {
-                let mut pyproject_file = File::create(pyproject_path).unwrap();
-                pyproject_file
-                    .write_all(updated_pyproject.to_string().as_bytes())
-                    .unwrap();
-
-                // Lock dependencies a second time, to remove constraints from lock file.
-                if !dry_run
-                    && !skip_lock
-                    && lock_dependencies(self.project_path.as_ref(), true).is_err()
-                {
-                    warn!(
-                        "An error occurred when locking dependencies after removing constraints."
-                    );
-                }
-            }
-        }
-
-        info!(
-            "{}",
-            "Successfully migrated project from Poetry to uv!\n"
-                .bold()
-                .green()
-        );
-    }
-
-    #[cfg(test)]
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
-impl Poetry {
-    fn perform_migration(
-        &self,
-        ignore_locked_versions: bool,
-        keep_old_metadata: bool,
-        dependency_groups_strategy: DependencyGroupsStrategy,
-    ) -> String {
+    fn perform_migration(&self) -> String {
         let pyproject_toml_content =
-            fs::read_to_string(self.project_path.join("pyproject.toml")).unwrap_or_default();
+            fs::read_to_string(self.get_project_path().join("pyproject.toml")).unwrap_or_default();
         let pyproject: PyProject = toml::from_str(pyproject_toml_content.as_str()).unwrap();
 
         let poetry = pyproject.tool.unwrap().poetry.unwrap();
@@ -133,7 +38,7 @@ impl Poetry {
             dependencies::get_dependency_groups_and_default_groups(
                 &poetry,
                 &mut uv_source_index,
-                dependency_groups_strategy,
+                self.get_dependency_groups_strategy(),
             );
         let mut poetry_dependencies = poetry.dependencies;
 
@@ -188,8 +93,8 @@ impl Poetry {
             },
             default_groups: uv_default_groups,
             constraint_dependencies: get_constraint_dependencies(
-                ignore_locked_versions,
-                &self.project_path.join("poetry.lock"),
+                !self.respect_locked_versions(),
+                &self.get_project_path().join("poetry.lock"),
             ),
         };
 
@@ -212,7 +117,7 @@ impl Poetry {
         pyproject_updater.insert_uv(&uv);
         pyproject_updater.insert_hatch(hatch.as_ref());
 
-        if !keep_old_metadata {
+        if !self.keep_old_metadata() {
             remove_pyproject_poetry_section(&mut updated_pyproject);
         }
 
@@ -224,16 +129,21 @@ impl Poetry {
         updated_pyproject.to_string()
     }
 
-    fn delete_poetry_references(&self) -> std::io::Result<()> {
-        for file in FILES_TO_DELETE {
-            let path = self.project_path.join(file);
+    fn get_package_manager_name(&self) -> String {
+        "Poetry".to_string()
+    }
 
-            if path.exists() {
-                remove_file(path)?;
-            }
-        }
+    fn get_converter_options(&self) -> &ConverterOptions {
+        &self.converter_options
+    }
 
-        Ok(())
+    fn get_migrated_files_to_delete(&self) -> Vec<String> {
+        vec!["poetry.lock".to_string(), "poetry.toml".to_string()]
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -249,6 +159,10 @@ fn remove_pyproject_poetry_section(pyproject: &mut DocumentMut) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::converters::DependencyGroupsStrategy;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     #[test]
@@ -267,10 +181,17 @@ mod tests {
             .unwrap();
 
         let poetry = Poetry {
-            project_path: PathBuf::from(project_path),
+            converter_options: ConverterOptions {
+                project_path: PathBuf::from(project_path),
+                dry_run: true,
+                skip_lock: true,
+                ignore_locked_versions: true,
+                keep_old_metadata: false,
+                dependency_groups_strategy: DependencyGroupsStrategy::SetDefaultGroups,
+            },
         };
 
-        insta::assert_snapshot!(poetry.perform_migration(true, false, DependencyGroupsStrategy::SetDefaultGroups), @r###"
+        insta::assert_snapshot!(poetry.perform_migration(), @r###"
         [project]
         name = ""
         version = "0.0.1"


### PR DESCRIPTION
Reduce code and logic duplication by relying on implementations in `Converter` trait, and passing down a new `ConverterOptions` struct that holds most of the dynamic data used in each converter.