### PR TITLE
refactor(converters): do not add `constraint-dependencies` on dry-run

### DIFF
--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -6,6 +6,7 @@ use owo_colors::OwoColorize;
 #[cfg(test)]
 use std::any::Any;
 use std::fmt::Debug;
+use std::format;
 use std::fs::{remove_file, File};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
@@ -41,15 +42,10 @@ pub trait Converter: Debug {
         let updated_pyproject_string = self.build_uv_pyproject();
 
         if self.is_dry_run() {
-            let mut pyproject_updater = PyprojectUpdater {
-                pyproject: &mut updated_pyproject_string.parse::<DocumentMut>().unwrap(),
-            };
             info!(
                 "{}\n{}",
                 "Migrated pyproject.toml:".bold(),
-                pyproject_updater
-                    .remove_constraint_dependencies()
-                    .map_or(updated_pyproject_string, ToString::to_string)
+                updated_pyproject_string
             );
             return;
         }
@@ -153,10 +149,16 @@ pub trait Converter: Debug {
         }
     }
 
+    /// Get dependencies constraints to set in `constraint-dependencies` under `[tool.uv]` section,
+    /// to keep dependencies locked to the same versions as they are with the current package
+    /// manager.
+    fn get_constraint_dependencies(&self) -> Option<Vec<String>>;
+
     /// Remove `constraint-dependencies` from `[tool.uv]` in `pyproject.toml`, unless user has
-    /// explicitly opted out of keeping versions locked in the current package manager.
+    /// opted out of keeping versions locked in the current package manager.
     ///
-    /// Also lock dependencies, to remove `constraints` from `[manifest]` in lock file.
+    /// Also lock dependencies, to remove `constraints` from `[manifest]` in lock file, unless user
+    /// has opted out of locking dependencies.
     fn remove_constraint_dependencies(&self, updated_pyproject_toml: String) {
         if !self.respect_locked_versions() {
             return;

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -135,12 +135,9 @@ pub trait Converter: Debug {
         Ok(())
     }
 
-    /// Lock dependencies with uv, unless dry-run mode is enabled, or user has explicitly opted out
-    /// from locking dependencies.
+    /// Lock dependencies with uv, unless user has explicitly opted out of locking dependencies.
     fn lock_dependencies(&self) {
-        if !self.is_dry_run()
-            && !self.skip_lock()
-            && lock_dependencies(self.get_project_path().as_ref(), false).is_err()
+        if !self.skip_lock() && lock_dependencies(self.get_project_path().as_ref(), false).is_err()
         {
             warn!(
                 "An error occurred when locking dependencies, so \"{}\" was not created.",
@@ -175,8 +172,7 @@ pub trait Converter: Debug {
                 .unwrap();
 
             // Lock dependencies a second time, to remove constraints from lock file.
-            if !self.is_dry_run()
-                && !self.skip_lock()
+            if !self.skip_lock()
                 && lock_dependencies(self.get_project_path().as_ref(), true).is_err()
             {
                 warn!("An error occurred when locking dependencies after removing constraints.");

--- a/src/converters/pip/dependencies.rs
+++ b/src/converters/pip/dependencies.rs
@@ -25,30 +25,3 @@ pub fn get(project_path: &Path, requirements_files: Vec<String>) -> Option<Vec<S
     }
     Some(dependencies)
 }
-
-pub fn get_constraint_dependencies(
-    ignore_locked_versions: bool,
-    is_pip_tools: bool,
-    project_path: &Path,
-    requirements_files: Vec<String>,
-    dev_requirements_files: Vec<String>,
-) -> Option<Vec<String>> {
-    if !is_pip_tools || ignore_locked_versions {
-        return None;
-    }
-
-    if let Some(dependencies) = get(
-        project_path,
-        requirements_files
-            .into_iter()
-            .chain(dev_requirements_files)
-            .map(|f| f.replace(".in", ".txt"))
-            .collect(),
-    ) {
-        if dependencies.is_empty() {
-            return None;
-        }
-        return Some(dependencies);
-    }
-    None
-}

--- a/src/converters/pipenv/dependencies.rs
+++ b/src/converters/pipenv/dependencies.rs
@@ -1,13 +1,9 @@
 use crate::converters::{DependencyGroupsAndDefaultGroups, DependencyGroupsStrategy};
 use crate::schema;
-use crate::schema::pipenv::{DependencySpecification, KeywordMarkers, PipenvLock};
+use crate::schema::pipenv::{DependencySpecification, KeywordMarkers};
 use crate::schema::pyproject::DependencyGroupSpecification;
 use crate::schema::uv::{SourceContainer, SourceIndex};
 use indexmap::IndexMap;
-use log::warn;
-use owo_colors::OwoColorize;
-use std::fs;
-use std::path::Path;
 
 pub fn get(
     pipenv_dependencies: Option<&IndexMap<String, DependencySpecification>>,
@@ -211,36 +207,4 @@ pub fn get_dependency_groups_and_default_groups(
             Some(default_groups)
         },
     )
-}
-
-pub fn get_constraint_dependencies(
-    ignore_locked_versions: bool,
-    pipenv_lock_path: &Path,
-) -> Option<Vec<String>> {
-    if ignore_locked_versions || !pipenv_lock_path.exists() {
-        return None;
-    }
-
-    let pipenv_lock_content = fs::read_to_string(pipenv_lock_path).unwrap();
-    let Ok(pipenv_lock) = serde_json::from_str::<PipenvLock>(pipenv_lock_content.as_str()) else {
-        warn!(
-            "Could not parse \"{}\", dependencies will not be kept to their current locked versions.",
-            "Pipfile.lock".bold()
-        );
-        return None;
-    };
-
-    let constraint_dependencies: Vec<String> = pipenv_lock
-        .category_groups
-        .unwrap_or_default()
-        .values()
-        .flatten()
-        .map(|(name, spec)| format!("{}{}", name, spec.version))
-        .collect();
-
-    if constraint_dependencies.is_empty() {
-        None
-    } else {
-        Some(constraint_dependencies)
-    }
 }

--- a/src/converters/poetry/dependencies.rs
+++ b/src/converters/poetry/dependencies.rs
@@ -1,15 +1,13 @@
 use crate::converters::poetry::sources;
 use crate::converters::{DependencyGroupsAndDefaultGroups, DependencyGroupsStrategy};
 use crate::schema;
-use crate::schema::poetry::{DependencySpecification, PoetryLock};
+use crate::schema::poetry::DependencySpecification;
 use crate::schema::pyproject::DependencyGroupSpecification;
 use crate::schema::uv::{SourceContainer, SourceIndex};
 use indexmap::IndexMap;
 use log::warn;
 use owo_colors::OwoColorize;
 use std::collections::HashSet;
-use std::fs;
-use std::path::Path;
 
 pub fn get(
     poetry_dependencies: Option<&IndexMap<String, DependencySpecification>>,
@@ -216,35 +214,4 @@ pub fn get_dependency_groups_and_default_groups(
             Some(default_groups)
         },
     )
-}
-
-pub fn get_constraint_dependencies(
-    ignore_locked_versions: bool,
-    poetry_lock_path: &Path,
-) -> Option<Vec<String>> {
-    if ignore_locked_versions || !poetry_lock_path.exists() {
-        return None;
-    }
-
-    let poetry_lock_content = fs::read_to_string(poetry_lock_path).unwrap();
-    let Ok(poetry_lock) = toml::from_str::<PoetryLock>(poetry_lock_content.as_str()) else {
-        warn!(
-            "Could not parse \"{}\", dependencies will not be kept to their current locked versions.",
-            "poetry.lock".bold()
-        );
-        return None;
-    };
-
-    let constraint_dependencies: Vec<String> = poetry_lock
-        .package
-        .unwrap_or_default()
-        .iter()
-        .map(|p| format!("{}=={}", p.name, p.version))
-        .collect();
-
-    if constraint_dependencies.is_empty() {
-        None
-    } else {
-        Some(constraint_dependencies)
-    }
 }


### PR DESCRIPTION
They are already not displayed in dry-run mode, but we currently force remove them from the output. Instead, do not add them in the first place in dry-run mode.