### PR TITLE
respect existing environments, if they are present

### DIFF
--- a/src/converters/pip/mod.rs
+++ b/src/converters/pip/mod.rs
@@ -59,6 +59,10 @@ impl Converter for Pip {
         let uv = Uv {
             package: Some(false),
             constraint_dependencies: self.get_constraint_dependencies(),
+            environments: pyproject
+                .tool
+                .and_then(|tool| tool.uv)
+                .and_then(|uv| uv.environments),
             ..Default::default()
         };
 

--- a/src/converters/pipenv/mod.rs
+++ b/src/converters/pipenv/mod.rs
@@ -62,6 +62,10 @@ impl Converter for Pipenv {
             },
             default_groups: uv_default_groups,
             constraint_dependencies: self.get_constraint_dependencies(),
+            environments: pyproject
+                .tool
+                .and_then(|tool| tool.uv)
+                .and_then(|uv| uv.environments),
         };
 
         let pyproject_toml_content =

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -33,7 +33,10 @@ impl Converter for Poetry {
             fs::read_to_string(self.get_project_path().join("pyproject.toml")).unwrap_or_default();
         let pyproject: PyProject = toml::from_str(pyproject_toml_content.as_str()).unwrap();
 
-        let poetry = pyproject.tool.unwrap().poetry.unwrap();
+        let (uv, poetry) = {
+            let tool = pyproject.tool.unwrap();
+            (tool.uv, tool.poetry.unwrap())
+        };
 
         let mut uv_source_index: IndexMap<String, SourceContainer> = IndexMap::new();
         let (dependency_groups, uv_default_groups) =
@@ -96,6 +99,7 @@ impl Converter for Poetry {
             },
             default_groups: uv_default_groups,
             constraint_dependencies: self.get_constraint_dependencies(),
+            environments: uv.and_then(|uv| uv.environments),
         };
 
         let hatch = get_hatch(

--- a/src/schema/uv.rs
+++ b/src/schema/uv.rs
@@ -13,6 +13,8 @@ pub struct Uv {
     pub default_groups: Option<Vec<String>>,
     #[serde(rename = "constraint-dependencies")]
     pub constraint_dependencies: Option<Vec<String>>,
+    /// <https://docs.astral.sh/uv/concepts/projects/config/#limited-resolution-environments>
+    pub environments: Option<Vec<String>>,
 }
 
 #[derive(Default, Deserialize, Serialize, Eq, PartialEq)]


### PR DESCRIPTION
Second part of https://github.com/mkniewallner/migrate-to-uv/issues/114.

I have a project where we have a couple of...not great practices for Python package management. Specifically:

- Different versions of xmlsec for macOS and Linux, because of xmlsec vs. the available libxmlsec in Homebrew issues.
- Several wheels that we have vendored into the repo, but only for the subset of environments in which we run.

Poetry is just fine with locking these dependencies, which is probably against specification, but `uv` rightfully complains that we have some unresolvable dependency sets. You can fix that by [specifying your environments](https://docs.astral.sh/uv/concepts/projects/config/#limited-resolution-environments), but this doesn't work with `migrate-to-uv`, because `migrate-to-uv` will overwrite the `tool.uv` section in `pyproject.toml`.

This PR just makes `migrate-to-uv` respect the `environments` which are present in `tool.uv` if they are present.

Note that this will still break unless https://github.com/mkniewallner/migrate-to-uv/pull/118 is also merged, because `migrate-to-uv` will early-exit if it sees a `tool.uv` section.