### PR TITLE
fix: use correct `include-group` name when including dependency groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* Use correct `include-group` name to include groups when using `--dependency-groups-strategy include-in-dev`
+
 ## 0.7.2 - 2025-03-25
 
 ### Bug fixes

--- a/docs/usage-and-configuration.md
+++ b/docs/usage-and-configuration.md
@@ -120,7 +120,7 @@ If this is not desirable, it is possible to change the strategy by using `--depe
   dependency groups in `default-groups` under `[tool.uv]` section (unless the only dependency group is `dev` one, as
   this is already uv's default)
 - `include-in-dev`:  Move each dependency group to its corresponding uv dependency group, and reference all dependency
-  groups (others than `dev` one) in `dev` dependency group by using `{ include = "<group>" }`
+  groups (others than `dev` one) in `dev` dependency group by using `{ include-group = "<group>" }`
 - `keep-existing`: Move each dependency group to its corresponding uv dependency group, without any further action
 - `merge-into-dev`: Merge dependencies from all dependency groups into `dev` dependency group
 

--- a/src/converters/pipenv/dependencies.rs
+++ b/src/converters/pipenv/dependencies.rs
@@ -172,14 +172,14 @@ pub fn get_dependency_groups_and_default_groups(
                 }
             }
             // When using `IncludeInDev` strategy, dependency groups (except `dev` one) are
-            // referenced from `dev` dependency group with `{ include = "<group>" }`.
+            // referenced from `dev` dependency group with `{ include-group = "<group>" }`.
             DependencyGroupsStrategy::IncludeInDev => {
                 dependency_groups
                     .entry("dev".to_string())
                     .or_default()
                     .extend(category_group.keys().filter(|&k| k != "dev").map(|g| {
                         DependencyGroupSpecification::Map {
-                            include: Some(g.to_string()),
+                            include_group: Some(g.to_string()),
                         }
                     }));
             }

--- a/src/converters/poetry/dependencies.rs
+++ b/src/converters/poetry/dependencies.rs
@@ -187,14 +187,14 @@ pub fn get_dependency_groups_and_default_groups(
                 }
             }
             // When using `IncludeInDev` strategy, dependency groups (except `dev` one) are
-            // referenced from `dev` dependency group with `{ include = "<group>" }`.
+            // referenced from `dev` dependency group with `{ include-group = "<group>" }`.
             DependencyGroupsStrategy::IncludeInDev => {
                 dependency_groups
                     .entry("dev".to_string())
                     .or_default()
                     .extend(poetry_group.keys().filter(|&k| k != "dev").map(|g| {
                         DependencyGroupSpecification::Map {
-                            include: Some(g.to_string()),
+                            include_group: Some(g.to_string()),
                         }
                     }));
             }

--- a/src/schema/pyproject.rs
+++ b/src/schema/pyproject.rs
@@ -18,7 +18,10 @@ pub struct PyProject {
 #[serde(untagged)]
 pub enum DependencyGroupSpecification {
     String(String),
-    Map { include: Option<String> },
+    Map {
+        #[serde(rename = "include-group")]
+        include_group: Option<String>,
+    },
 }
 
 #[derive(Deserialize, Serialize)]

--- a/tests/pipenv.rs
+++ b/tests/pipenv.rs
@@ -285,7 +285,7 @@ fn test_dependency_groups_strategy_include_in_dev() {
     [dependency-groups]
     dev = [
         "mypy>=1.13.0",
-        { include = "test" },
+        { include-group = "test" },
     ]
     test = ["factory-boy>=3.2.1"]
 

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -284,7 +284,7 @@ fn test_dependency_groups_strategy_include_in_dev() {
     [dependency-groups]
     dev = [
         "factory-boy>=3.2.1,<4",
-        { include = "typing" },
+        { include-group = "typing" },
     ]
     typing = ["mypy>=1.13.0,<2"]
 


### PR DESCRIPTION
Spotted thanks to https://github.com/mkniewallner/migrate-to-uv/actions/runs/15429145556/job/43423277164?pr=263.