### PR TITLE
fix(poetry): abort migration on dependencies using `||` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Warnings that occurred during the migration (which did not break the behaviour) 
 * [poetry] Use inclusion when converting `^x.y` versions ([#466](https://github.com/mkniewallner/migrate-to-uv/pull/466))
 * [poetry] Properly convert `include` to Hatch's build backend ([#477](https://github.com/mkniewallner/migrate-to-uv/pull/477))
 * [poetry] Do not crash on empty `readme` array ([#481](https://github.com/mkniewallner/migrate-to-uv/pull/481))
+* [poetry] Abort migration on dependencies using `||` operator, as there is no PEP 440 equivalent ([#487](https://github.com/mkniewallner/migrate-to-uv/pull/487))
 * [pip/pip-tools] Suggest how to add dependencies that could not be converted ([#350](https://github.com/mkniewallner/migrate-to-uv/pull/350))
 * Preserve comments for sections unrelated to migration ([#471](https://github.com/mkniewallner/migrate-to-uv/pull/471))
 

--- a/tests/fixtures/poetry/with_migration_errors/pyproject.toml
+++ b/tests/fixtures/poetry/with_migration_errors/pyproject.toml
@@ -2,3 +2,24 @@
 name = "foobar"
 # PEP 621 does not support multiple readme, this will abort the migration.
 readme = ["README.md", "README2.md"]
+
+[tool.poetry.dependencies]
+# PEP 621 does not support `||` operator, or `|` which are equivalent in Poetry, so this will abort the migration.
+caret-or = "^1.0||^2.0||^3.0"
+caret-or-single = "^1.0|^2.0|^3.0"
+caret-or-whitespaces = " ^1.0 || ^2.0  ||  ^3.0 "
+caret-or-mix-single-double-whitespaces = " ^1.0 | ^2.0  ||  ^3.0 "
+caret-or-table-version = { version = "^1.0||^2.0||^3.0" }
+caret-or-multiple-constraints = [
+    { python = ">=3.11", version = "^1.0||^2.0||^3.0" },
+    { python = "<3.11", version = "^1.0||^2.0" },
+]
+tilde-or = "~1.0||~2.0||~3.0"
+tilde-or-single = "~1.0|~2.0|~3.0"
+tilde-or-whitespaces = " ~1.0 || ~2.0  ||  ~3.0 "
+tilde-or-mix-single-double-whitespaces = " ~1.0 | ~2.0  ||  ~3.0 "
+tilde-or-table-version = { version = "~1.0||~2.0||~3.0" }
+tilde-or-multiple-constraints = [
+    { python = ">=3.11", version = "~1.0||~2.0||~3.0" },
+    { python = "<3.11", version = "~1.0||~2.0" },
+]

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -1018,6 +1018,20 @@ fn test_manage_errors() {
     ----- stderr -----
     error: Could not automatically migrate the project to uv because of the following errors:
     error: - Found multiple files ("README.md", "README2.md") in "tool.poetry.readme". PEP 621 only supports setting one. Make sure to manually edit the section before migrating.
+    error: - "caret-or" dependency with version "^1.0||^2.0||^3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-single" dependency with version "^1.0|^2.0|^3.0" contains "|", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "|" before migrating.
+    error: - "caret-or-whitespaces" dependency with version " ^1.0 || ^2.0  ||  ^3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-mix-single-double-whitespaces" dependency with version " ^1.0 | ^2.0  ||  ^3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-table-version" dependency with version "^1.0||^2.0||^3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-multiple-constraints" dependency with version "^1.0||^2.0||^3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-multiple-constraints" dependency with version "^1.0||^2.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or" dependency with version "~1.0||~2.0||~3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-single" dependency with version "~1.0|~2.0|~3.0" contains "|", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "|" before migrating.
+    error: - "tilde-or-whitespaces" dependency with version " ~1.0 || ~2.0  ||  ~3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-mix-single-double-whitespaces" dependency with version " ~1.0 | ~2.0  ||  ~3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-table-version" dependency with version "~1.0||~2.0||~3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-multiple-constraints" dependency with version "~1.0||~2.0||~3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-multiple-constraints" dependency with version "~1.0||~2.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
     "#);
 
     // Assert that `pyproject.toml` was not updated.
@@ -1156,6 +1170,20 @@ fn test_manage_errors_dry_run() {
     ----- stderr -----
     error: Could not automatically migrate the project to uv because of the following errors:
     error: - Found multiple files ("README.md", "README2.md") in "tool.poetry.readme". PEP 621 only supports setting one. Make sure to manually edit the section before migrating.
+    error: - "caret-or" dependency with version "^1.0||^2.0||^3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-single" dependency with version "^1.0|^2.0|^3.0" contains "|", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "|" before migrating.
+    error: - "caret-or-whitespaces" dependency with version " ^1.0 || ^2.0  ||  ^3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-mix-single-double-whitespaces" dependency with version " ^1.0 | ^2.0  ||  ^3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-table-version" dependency with version "^1.0||^2.0||^3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-multiple-constraints" dependency with version "^1.0||^2.0||^3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "caret-or-multiple-constraints" dependency with version "^1.0||^2.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or" dependency with version "~1.0||~2.0||~3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-single" dependency with version "~1.0|~2.0|~3.0" contains "|", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "|" before migrating.
+    error: - "tilde-or-whitespaces" dependency with version " ~1.0 || ~2.0  ||  ~3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-mix-single-double-whitespaces" dependency with version " ~1.0 | ~2.0  ||  ~3.0 " contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-table-version" dependency with version "~1.0||~2.0||~3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-multiple-constraints" dependency with version "~1.0||~2.0||~3.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
+    error: - "tilde-or-multiple-constraints" dependency with version "~1.0||~2.0" contains "||", which is specific to Poetry and not supported by PEP 440. Make sure to manually adapt the version to not depend on "||" before migrating.
     "#);
 
     // Assert that `pyproject.toml` was not updated.


### PR DESCRIPTION
Closes #424.

Poetry defines an `||` operator (which can also be expressed as `|`) to make an or condition, which is rarely used, e.g.:

```toml
[tool.poetry.dependencies]
pytest = "^7.0 || ^8.0 || ^9.0"
```

Since there is no equivalent in [PEP 440 version specifier](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers), we want to abort the migration and ask the user to manually change the specifier before migrating.