### PR TITLE
fix(poetry): do not migrate `packages`/`include` with empty `format` array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* [poetry] Do not migrate `packages`/`include` with empty `format` array ([#538](https://github.com/mkniewallner/migrate-to-uv/pull/538))
+
 ## 0.8.1 - 2025-12-13
 
 ### Bug fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* [poetry] Do not migrate `packages`/`include` with empty `format` array ([#538](https://github.com/mkniewallner/migrate-to-uv/pull/538))
+
 ## 0.8.1 - 2025-12-13
 
 ### Bug fixes

--- a/src/converters/poetry/build_backend.rs
+++ b/src/converters/poetry/build_backend.rs
@@ -133,11 +133,14 @@ fn get_hatch_include(
                         wheel_sources.insert(from, to);
                     }
                 }
+                // Note: An empty `format = []` in Poetry means that the files will not be added to
+                // any distribution at all.
                 Some(SingleOrVec::Vec(vec)) => {
-                    if vec.contains(&Format::Sdist) || vec.is_empty() {
+                    if vec.contains(&Format::Sdist) {
                         sdist_include.push(include_with_from.clone());
                     }
-                    if vec.contains(&Format::Wheel) || vec.is_empty() {
+
+                    if vec.contains(&Format::Wheel) {
                         wheel_include.push(include_with_from.clone());
 
                         if let Some((from, to)) = get_hatch_source(
@@ -165,13 +168,22 @@ fn get_hatch_include(
                 }
                 Include::Map {
                     path,
+                    format: Some(SingleOrVec::Single(Format::Sdist)),
+                } => {
+                    sdist_force_include.insert(path.clone(), path.clone());
+                }
+                Include::Map {
+                    path,
+                    format: Some(SingleOrVec::Single(Format::Wheel)),
+                } => {
+                    wheel_force_include.insert(path.clone(), path.clone());
+                }
+                // Note: An empty `format = []` in Poetry means that the files will not be added to
+                // any distribution at all.
+                Include::Map {
+                    path,
                     format: Some(SingleOrVec::Vec(format)),
                 } => match format[..] {
-                    [] => {
-                        // https://python-poetry.org/docs/1.8/pyproject/#include-and-exclude
-                        // If there is no format specified, files are only added to sdist.
-                        sdist_force_include.insert(path.clone(), path.clone());
-                    }
                     [Format::Sdist, Format::Wheel] => {
                         sdist_force_include.insert(path.clone(), path.clone());
                         wheel_force_include.insert(path.clone(), path.clone());
@@ -184,18 +196,6 @@ fn get_hatch_include(
                     }
                     _ => (),
                 },
-                Include::Map {
-                    path,
-                    format: Some(SingleOrVec::Single(Format::Sdist)),
-                } => {
-                    sdist_force_include.insert(path.clone(), path.clone());
-                }
-                Include::Map {
-                    path,
-                    format: Some(SingleOrVec::Single(Format::Wheel)),
-                } => {
-                    wheel_force_include.insert(path.clone(), path.clone());
-                }
             }
         }
     }

--- a/tests/fixtures/poetry/full/pyproject.toml
+++ b/tests/fixtures/poetry/full/pyproject.toml
@@ -31,19 +31,21 @@ documentation = "https://docs.example.com"
 # Package metadata
 packages = [
     { include = "packages_sdist_wheel" },
-    { include = "packages_sdist_wheel_2", format = [] },
-    { include = "packages_sdist_wheel_3", format = ["sdist", "wheel"] },
+    { include = "packages_sdist_wheel_2", format = ["sdist", "wheel"] },
     { include = "packages_sdist", format = "sdist" },
     { include = "packages_sdist_2", format = ["sdist"] },
     { include = "packages_wheel", format = "wheel" },
     { include = "packages_wheel_2", format = ["wheel"] },
+    # An empty array for `format` means that files are not included anywhere.
+    { include = "packages_nowhere", format = [] },
     { include = "packages_glob_sdist_wheel/**/*.py" },
-    { include = "packages_glob_sdist_wheel_2/**/*.py", format = [] },
-    { include = "packages_glob_sdist_wheel_3/**/*.py", format = ["sdist", "wheel"] },
+    { include = "packages_glob_sdist_wheel_2/**/*.py", format = ["sdist", "wheel"] },
     { include = "packages_glob_sdist/**/*.py", format = "sdist" },
     { include = "packages_glob_sdist_2/**/*.py", format = ["sdist"] },
     { include = "packages_glob_wheel/**/*.py", format = "wheel" },
     { include = "packages_glob_wheel_2/**/*.py", format = ["wheel"] },
+    # An empty array for `format` means that files are not included anywhere.
+    { include = "packages_glob_nowhere/**/*.py", format = [] },
     { include = "packages_from", from = "from" },
     { include = "packages_to", to = "to" },
     { include = "packages_from_to", from = "from", to = "to" },
@@ -56,12 +58,13 @@ packages = [
 include = [
     "include_sdist",
     { path = "include_sdist_2" },
-    { path = "include_sdist_3", format = [] },
-    { path = "include_sdist_4", format = "sdist" },
-    { path = "include_sdist_5", format = ["sdist"] },
+    { path = "include_sdist_3", format = "sdist" },
+    { path = "include_sdist_4", format = ["sdist"] },
     { path = "include_sdist_wheel", format = ["sdist", "wheel"] },
     { path = "include_wheel", format = "wheel" },
     { path = "include_wheel_2", format = ["wheel"] },
+    # An empty array for `format` means that files are not included anywhere.
+    { path = "include_nowhere", format = [] },
 ]
 exclude = [
     "exclude_sdist_wheel",

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -788,12 +788,10 @@ fn test_skip_lock_full() {
     include = [
         "packages_sdist_wheel",
         "packages_sdist_wheel_2",
-        "packages_sdist_wheel_3",
         "packages_sdist",
         "packages_sdist_2",
         "packages_glob_sdist_wheel/**/*.py",
         "packages_glob_sdist_wheel_2/**/*.py",
-        "packages_glob_sdist_wheel_3/**/*.py",
         "packages_glob_sdist/**/*.py",
         "packages_glob_sdist_2/**/*.py",
         "from/packages_from",
@@ -814,19 +812,16 @@ fn test_skip_lock_full() {
     include_sdist_2 = "include_sdist_2"
     include_sdist_3 = "include_sdist_3"
     include_sdist_4 = "include_sdist_4"
-    include_sdist_5 = "include_sdist_5"
     include_sdist_wheel = "include_sdist_wheel"
 
     [tool.hatch.build.targets.wheel]
     include = [
         "packages_sdist_wheel",
         "packages_sdist_wheel_2",
-        "packages_sdist_wheel_3",
         "packages_wheel",
         "packages_wheel_2",
         "packages_glob_sdist_wheel/**/*.py",
         "packages_glob_sdist_wheel_2/**/*.py",
-        "packages_glob_sdist_wheel_3/**/*.py",
         "packages_glob_wheel/**/*.py",
         "packages_glob_wheel_2/**/*.py",
         "from/packages_from",


### PR DESCRIPTION
Spotted while working on #533.

An empty `format = []` in Poetry means that the files will not be included in any distribution, both for `packages` and `include`, while I initially wrongly assumed that it would be equivalent to not specifying the key at all.