### PR TITLE
fix(poetry): fail migration on unhandled python marker specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [poetry] Do not migrate `packages`/`include` with empty `format` array ([#538](https://github.com/mkniewallner/migrate-to-uv/pull/538))
+* [poetry] Fail migration on unhandled python marker specification ([#544](https://github.com/mkniewallner/migrate-to-uv/pull/544))
 
 ## 0.8.1 - 2025-12-13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [poetry] Do not migrate `packages`/`include` with empty `format` array ([#538](https://github.com/mkniewallner/migrate-to-uv/pull/538))
+* [poetry] Fail migration on unhandled python marker specification ([#544](https://github.com/mkniewallner/migrate-to-uv/pull/544))
 
 ## 0.8.1 - 2025-12-13
 

--- a/src/converters/poetry/dependencies.rs
+++ b/src/converters/poetry/dependencies.rs
@@ -54,7 +54,10 @@ pub fn get(
                         } = spec
                             && (python.is_some() || platform.is_some() || markers.is_some())
                         {
-                            source_index.marker = spec.get_marker();
+                            match spec.get_marker() {
+                                Ok(marker) => source_index.marker = marker,
+                                Err(e) => add_unrecoverable_error(e.format(name)),
+                            }
                         }
 
                         source_indexes.push(source_index);

--- a/src/converters/poetry/version.rs
+++ b/src/converters/poetry/version.rs
@@ -56,6 +56,8 @@ impl PoetryPep440 {
 pub enum ParseVersionErrorKind {
     OrOperator(String),
     Other,
+    PythonMarkerOrOperator(String),
+    PythonMarker,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -77,6 +79,21 @@ impl ParseVersionError {
                     dependency.bold(),
                     self.version.bold(),
                     operator.bold(),
+                )
+            }
+            ParseVersionErrorKind::PythonMarkerOrOperator(operator) => {
+                format!(
+                    "\"{}\" dependency with python marker \"{}\" contains \"{}\", which is specific to Poetry and not supported by PEP 440. See https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#operator for guidance.",
+                    dependency.bold(),
+                    self.version.bold(),
+                    operator.bold(),
+                )
+            }
+            ParseVersionErrorKind::PythonMarker => {
+                format!(
+                    "\"{}\" dependency with python marker \"{}\" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.",
+                    dependency.bold(),
+                    self.version.bold(),
                 )
             }
             ParseVersionErrorKind::Other => {

--- a/tests/fixtures/poetry/with_migration_errors/pyproject.toml
+++ b/tests/fixtures/poetry/with_migration_errors/pyproject.toml
@@ -29,3 +29,6 @@ whitespace = ">=7.0 <7.1"
 whitespace-multiple = ">=7.0  <7.1"
 whitespace-caret = "^7.0 ^7.1"
 whitespace-caret-multiple = "^7.0  ^7.1"
+python-caret-or = { version = "1.2.3", python = "^3.11 || ^3.12" }
+python-caret-or-single = { version = "1.2.3", python = "^3.11 | ^3.12" }
+python-whitespace = { version = "1.2.3", python = "^3.11 <=3.14"}

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -1174,6 +1174,9 @@ fn test_manage_errors() {
     error: - "whitespace-multiple" dependency with version ">=7.0  <7.1" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
     error: - "whitespace-caret" dependency with version "7.0 ^7.1" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
     error: - "whitespace-caret-multiple" dependency with version "7.0  ^7.1" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
+    error: - "python-caret-or" dependency with python marker "^3.11 || ^3.12" contains "||", which is specific to Poetry and not supported by PEP 440. See https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#operator for guidance.
+    error: - "python-caret-or-single" dependency with python marker "^3.11 | ^3.12" contains "|", which is specific to Poetry and not supported by PEP 440. See https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#operator for guidance.
+    error: - "python-whitespace" dependency with python marker "3.11 <=3.14" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
     "#);
 
     // Assert that `pyproject.toml` was not updated.
@@ -1330,6 +1333,9 @@ fn test_manage_errors_dry_run() {
     error: - "whitespace-multiple" dependency with version ">=7.0  <7.1" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
     error: - "whitespace-caret" dependency with version "7.0 ^7.1" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
     error: - "whitespace-caret-multiple" dependency with version "7.0  ^7.1" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
+    error: - "python-caret-or" dependency with python marker "^3.11 || ^3.12" contains "||", which is specific to Poetry and not supported by PEP 440. See https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#operator for guidance.
+    error: - "python-caret-or-single" dependency with python marker "^3.11 | ^3.12" contains "|", which is specific to Poetry and not supported by PEP 440. See https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#operator for guidance.
+    error: - "python-whitespace" dependency with python marker "3.11 <=3.14" could not be transformed to PEP 440 format. Make sure to check https://mkniewallner.github.io/migrate-to-uv/supported-package-managers/#unsupported-version-specifiers.
     "#);
 
     // Assert that `pyproject.toml` was not updated.


### PR DESCRIPTION
Same as https://github.com/mkniewallner/migrate-to-uv/pull/514, but for `python` marker.