### PR TITLE
ci: install Python in `tests`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
         with:
           version: ${{ env.UV_VERSION }}
+          
+      - name: Install Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run unit tests
         run: make test-unit


### PR DESCRIPTION
Windows image [uses Python 3.9](https://github.com/actions/runner-images/blob/4e4e6cdb364028b0286aa4fc0a31f8f32036f57d/images/windows/Windows2025-Readme.md), and `uvicorn` that is used as a dependency in pip tests recently [dropped 3.9 support](https://github.com/Kludex/uvicorn/releases/tag/0.40.0). This causes [tests to fail](https://github.com/mkniewallner/migrate-to-uv/actions/runs/20416654271/job/58661314873). Installing a specific version of Python during the tests should limit flakiness.