### PR TITLE
fix(poetry): use `python_full_version` for 3-components Python markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [poetry] Fix typo on `--build-backend` error message ([#571](https://github.com/mkniewallner/migrate-to-uv/pull/571))
+* [poetry] Use `python_full_version` for 3-components Python markers ([#559](https://github.com/mkniewallner/migrate-to-uv/pull/559))
 
 ## 0.9.1 - 2025-12-24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ icon: lucide/scroll-text
 ### Bug fixes
 
 * [poetry] Fix typo on `--build-backend` error message ([#571](https://github.com/mkniewallner/migrate-to-uv/pull/571))
+* [poetry] Use `python_full_version` for 3-components Python markers ([#559](https://github.com/mkniewallner/migrate-to-uv/pull/559))
 
 ## 0.9.1 - 2025-12-24
 

--- a/src/converters/poetry/version.rs
+++ b/src/converters/poetry/version.rs
@@ -14,7 +14,13 @@ impl PoetryPep440 {
 
         pep_440_python
             .iter()
-            .map(|spec| format!("python_version {} '{}'", spec.operator(), spec.version()))
+            .map(|spec| {
+                let marker = match spec.version().release().len() {
+                    3.. => "python_full_version",
+                    _ => "python_version",
+                };
+                format!("{marker} {} '{}'", spec.operator(), spec.version())
+            })
             .collect::<Vec<String>>()
             .join(" and ")
     }

--- a/tests/fixtures/poetry/full/pyproject.toml
+++ b/tests/fixtures/poetry/full/pyproject.toml
@@ -131,6 +131,7 @@ python-restricted-4 = { version = "1.2.3", python = ">=3.11" }
 python-restricted-5 = { version = "1.2.3", python = "<3.11" }
 python-restricted-6 = { version = "1.2.3", python = "<=3.11" }
 python-restricted-7 = { version = "1.2.3", python = ">3.11,<3.13" }
+python-restricted-full-version = { version = "1.2.3", python = "^3.11.2" }
 python-restricted-with-source = { version = "1.2.3", python = ">3.11,<3.13", source = "supplemental" }
 
 # Going wild

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -692,6 +692,7 @@ fn test_skip_lock_full() {
         "python-restricted-5==1.2.3 ; python_version < '3.11'",
         "python-restricted-6==1.2.3 ; python_version <= '3.11'",
         "python-restricted-7==1.2.3 ; python_version > '3.11' and python_version < '3.13'",
+        "python-restricted-full-version==1.2.3 ; python_full_version >= '3.11.2' and python_version < '4'",
         "python-restricted-with-source==1.2.3 ; python_version > '3.11' and python_version < '3.13'",
         "whitespaces>=3.2,<4",
         "whitespaces-2     >   3.11,     <=     3.13    ",


### PR DESCRIPTION
Closes #542.