### PR TITLE
feat(poetry): choose build backend based on distribution complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,24 @@
 
 ## Unreleased
 
-### New features
+### Breaking changes
+
+#### Automatic selection of build backend
+
+When migrating Poetry package distribution metadata, `migrate-to-uv` now automatically chooses the build backend to use based on the metadata complexity, prioritising [uv](https://docs.astral.sh/uv/concepts/build-backend/) if it is simple enough, or using [Hatch](https://hatch.pypa.io/latest/config/build/) otherwise.
+
+It is still possible to explicitly choose a specific build backend with `--build-backend hatch` or `--build-backend uv`, but if the latter is chosen and the package distribution metadata cannot be expressed with uv build backend, the migration will fail, suggesting to use `--build-backend hatch` instead.
+
+### Features
 
 * Abort migration early if uv executable is required but not found ([#558](https://github.com/mkniewallner/migrate-to-uv/pull/558))
+* [poetry] Choose build backend based on distribution complexity ([#597](https://github.com/mkniewallner/migrate-to-uv/pull/597))
 
 ### Bug fixes
 
 * [poetry] Fix typo on `--build-backend` error message ([#571](https://github.com/mkniewallner/migrate-to-uv/pull/571))
 * [poetry] Use `python_full_version` for 3-components Python markers ([#559](https://github.com/mkniewallner/migrate-to-uv/pull/559))
-* [poetry] Handle platform markers delimited by pipe ([#576](https://github.com/mkniewallner/migrate-to-uv/pull/576))
+* [poetry] Handle platform markers delimited by pipe ([#576](https://github.com/mkniewallner/migrate-to-uv/pull/576), [#498](https://github.com/mkniewallner/migrate-to-uv/pull/498))
 * [poetry] Avoid empty arrays in uv build backend ([#582](https://github.com/mkniewallner/migrate-to-uv/pull/582))
 * [poetry] Consistently use `python_full_version` for Python markers to match uv behavior ([#583](https://github.com/mkniewallner/migrate-to-uv/pull/583))
 * [poetry] Fail on wheel-only packages using array for uv build backend ([#595](https://github.com/mkniewallner/migrate-to-uv/pull/595))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,15 +5,24 @@ icon: lucide/scroll-text
 
 ## Unreleased
 
-### New features
+### Breaking changes
+
+#### Automatic selection of build backend
+
+When migrating Poetry package distribution metadata, `migrate-to-uv` now automatically chooses the build backend to use based on the metadata complexity, prioritising [uv](https://docs.astral.sh/uv/concepts/build-backend/) if it is simple enough, or using [Hatch](https://hatch.pypa.io/latest/config/build/) otherwise.
+
+It is still possible to explicitly choose a specific build backend with `--build-backend hatch` or `--build-backend uv`, but if the latter is chosen and the package distribution metadata cannot be expressed with uv build backend, the migration will fail, suggesting to use `--build-backend hatch` instead.
+
+### Features
 
 * Abort migration early if uv executable is required but not found ([#558](https://github.com/mkniewallner/migrate-to-uv/pull/558))
+* [poetry] Choose build backend based on distribution complexity ([#597](https://github.com/mkniewallner/migrate-to-uv/pull/597))
 
 ### Bug fixes
 
 * [poetry] Fix typo on `--build-backend` error message ([#571](https://github.com/mkniewallner/migrate-to-uv/pull/571))
 * [poetry] Use `python_full_version` for 3-components Python markers ([#559](https://github.com/mkniewallner/migrate-to-uv/pull/559))
-* [poetry] Handle platform markers delimited by pipe ([#576](https://github.com/mkniewallner/migrate-to-uv/pull/576))
+* [poetry] Handle platform markers delimited by pipe ([#576](https://github.com/mkniewallner/migrate-to-uv/pull/576), [#498](https://github.com/mkniewallner/migrate-to-uv/pull/498))
 * [poetry] Avoid empty arrays in uv build backend ([#582](https://github.com/mkniewallner/migrate-to-uv/pull/582))
 * [poetry] Consistently use `python_full_version` for Python markers to match uv behavior ([#583](https://github.com/mkniewallner/migrate-to-uv/pull/583))
 * [poetry] Fail on wheel-only packages using array for uv build backend ([#595](https://github.com/mkniewallner/migrate-to-uv/pull/595))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,17 +102,15 @@ migrate-to-uv --package-manager poetry
 
 ### `--build-backend`
 
-The build backend to choose when performing the migration. If the option is not provided, `hatch` is chosen by default.
-
-!!!info
-
-    Support for `uv` is considered experimental, but the default will likely change in the future, where the build
-    backend will be chosen based on the complexity of the package distribution metadata.
+The build backend to choose when performing the migration. If the option is not provided, the build backend will be
+automatically chosen based on the package distribution complexity,
+using [uv](https://docs.astral.sh/uv/concepts/build-backend/) if it is simple enough, or
+using [Hatch](https://hatch.pypa.io/latest/config/build/) otherwise.
 
 !!!note
 
-    If you choose `uv` and the migration cannot be performed because the project uses package distribution metadata that
-    cannot be expressed with uv build backend, the migration will fail, suggesting to use hatch with
+    If you explicitly choose `uv` and the migration cannot be performed because the project uses package distribution
+    metadata that cannot be expressed with uv build backend, the migration will fail, suggesting to use hatch with
     `--build-backend hatch`.
 
 **Available options**:

--- a/docs/supported-package-managers.md
+++ b/docs/supported-package-managers.md
@@ -108,15 +108,9 @@ migration.
 ### Build backend
 
 Although uv has [its own build backend](https://docs.astral.sh/uv/concepts/build-backend/), it cannot express everything
-that Poetry supports. Additionally, `migrate-to-uv` was created before uv build backend was stabilized, and
-chose [Hatch](https://hatch.pypa.io/latest/config/build/) in the meantime.
-
-!!! info
-
-    Support for uv build backend was recently added, but is still considered experimental, so Hatch is still used by
-    default. If you want to explicitly use uv as a build backend, you can
-    use [`--build-backend uv`](configuration.md#-build-backend), but note that the migration can fail if you use some
-    package distribution options that cannot be expressed with uv build backend.
+that Poetry supports. For this reason, `migrate-to-uv` prioritises using uv if the package distribution metadata is
+simple enough to use it, but uses [Hatch](https://hatch.pypa.io/latest/config/build/) otherwise. It is possible to
+explicitly choose a build backend by using [`--build-backend`](configuration.md#-build-backend).
 
 When converting the build backend to Hatch, `migrate-to-uv` migrates the following things:
 

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -195,11 +195,6 @@ pub trait Converter: Any + Debug {
         self.get_converter_options().dependency_groups_strategy
     }
 
-    /// Build backend to use when migrating package distribution metadata.
-    fn get_build_backend(&self) -> Option<BuildBackend> {
-        self.get_converter_options().build_backend
-    }
-
     /// List of files tied to the current package manager to delete at the end of the migration.
     fn get_migrated_files_to_delete(&self) -> Vec<String>;
 

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -121,7 +121,7 @@ impl Converter for Poetry {
         };
 
         pyproject_updater.insert_build_system(
-            build_backend::get_new_build_system(pyproject.build_system, self.get_build_backend())
+            build_backend::get_new_build_system(pyproject.build_system, build_backend.as_ref())
                 .as_ref(),
         );
         pyproject_updater.insert_pep_621(&self.build_project(pyproject.project, project));


### PR DESCRIPTION
Closes #537.

Automatically select the build backend to use for the migration based on the project distribution metadata if no `--build-backend` argument is set.

We basically try to instantiate uv build backend first, and fall back to using Hatch if an error is found when building it.