### PR TITLE
feat(poetry): automatically add Python classifiers for packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 
 * Abort migration early if uv executable is required but not found ([#558](https://github.com/mkniewallner/migrate-to-uv/pull/558))
 * [poetry] Choose build backend based on distribution complexity ([#597](https://github.com/mkniewallner/migrate-to-uv/pull/597))
+* [poetry] Automatically add Python classifiers for packages based on `python` specifier ([#606](https://github.com/mkniewallner/migrate-to-uv/pull/606))
 
 ### Bug fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 
 * Abort migration early if uv executable is required but not found ([#558](https://github.com/mkniewallner/migrate-to-uv/pull/558))
 * [poetry] Choose build backend based on distribution complexity ([#597](https://github.com/mkniewallner/migrate-to-uv/pull/597))
+* [poetry] Automatically add Python classifiers for packages based on `python` specifier ([#606](https://github.com/mkniewallner/migrate-to-uv/pull/606))
 
 ### Bug fixes
 

--- a/docs/supported-package-managers.md
+++ b/docs/supported-package-managers.md
@@ -122,6 +122,57 @@ When converting the build backend to Hatch, `migrate-to-uv` migrates the followi
     Path rewriting, defined with `to` in `packages` for Poetry, is also migrated to Hatch by defining
     [sources](https://hatch.pypa.io/latest/config/build/#rewriting-paths) in wheel target.
 
+### Specificities
+
+#### Python classifiers
+
+When building distributions,
+Poetry [automatically adds Python classifiers](https://python-poetry.org/docs/pyproject#classifiers-1) based on the
+Python versions allowed by `python` under `[tool.poetry.dependencies]`. Since uv does not, if `migrate-to-uv` detects
+that Poetry build backend is used, it will assume that the project is a package, and will add the classifiers in
+`classifiers` under `[project]` section, in order to not lose those classifiers after the migration.
+
+For instance, this `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "foo"
+version = "0.0.1"
+
+[tool.poetry.dependencies]
+python = ">=3.10"
+```
+
+would get converted to:
+
+```toml
+[build-system]
+requires = ["uv_build"]
+build-backend = "uv_build"
+
+[project]
+name = "foo"
+version = "0.0.1"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+```
+
+!!! note
+
+    Python classifiers will not get automatically added if a `classifiers` key is already defined under `[project]`
+    section, as Poetry [does not add them](https://python-poetry.org/docs/pyproject#classifiers) in that specific case.
+
 ## Pipenv
 
 All existing [Pipenv](https://pipenv.pypa.io/en/stable/) metadata should be converted to uv when performing the

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -197,6 +197,13 @@ fn test_complete_workflow_pep_621_no_poetry_section() {
     version = "0.1.0"
     description = "A fabulous project."
     requires-python = ">=3.11"
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+    ]
     dependencies = ["arrow>=1.2.3,<2"]
 
     [dependency-groups]
@@ -645,6 +652,11 @@ fn test_skip_lock_full() {
         "License :: OSI Approved :: MIT License",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ]
     dependencies = [
         "caret>=1.2.3,<2",
@@ -1454,6 +1466,14 @@ fn test_build_backend_auto_hatch() {
     description = "A fabulous project."
     authors = [{ name = "John Doe", email = "john.doe@example.com" }]
     requires-python = ">=3.10"
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+    ]
 
     [tool.hatch.build.targets.sdist]
     include = [
@@ -1587,6 +1607,14 @@ fn test_build_backend_auto_uv() {
     description = "A fabulous project."
     authors = [{ name = "John Doe", email = "john.doe@example.com" }]
     requires-python = ">=3.10"
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+    ]
 
     [tool.uv.build-backend]
     module-name = [
@@ -1683,6 +1711,14 @@ fn test_build_backend_hatch() {
     description = "A fabulous project."
     authors = [{ name = "John Doe", email = "john.doe@example.com" }]
     requires-python = ">=3.10"
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+    ]
 
     [tool.hatch.build.targets.sdist]
     include = [
@@ -1816,6 +1852,14 @@ fn test_build_backend_uv() {
     description = "A fabulous project."
     authors = [{ name = "John Doe", email = "john.doe@example.com" }]
     requires-python = ">=3.10"
+    classifiers = [
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+    ]
 
     [tool.uv.build-backend]
     module-name = [


### PR DESCRIPTION
Closes #603.

Automatically add Python classifiers based on the Python specifier if a project uses Poetry build backend, as Poetry [does that automatically](https://python-poetry.org/docs/pyproject#classifiers-1) when building distributions and uv does not.

If a `classifiers` key is defined under `[project]` section, we don't add the classifiers, to match [Poetry's behaviour](https://python-poetry.org/docs/pyproject#classifiers).