### PR TITLE
fix(poetry): avoid converting empty `extras` for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Fail on wheel-only packages using array for uv build backend ([#595](https://github.com/mkniewallner/migrate-to-uv/pull/595))
 * [poetry] Abort migration for files using `from` in `packages` ([#567](https://github.com/mkniewallner/migrate-to-uv/pull/567))
 * [poetry] Abort migration on `packages` using `from`/`to` and glob ([#615](https://github.com/mkniewallner/migrate-to-uv/pull/615))
+* [poetry] Avoid converting empty `extras` for dependencies ([#624](https://github.com/mkniewallner/migrate-to-uv/pull/624))
 
 ## 0.9.1 - 2025-12-24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Fail on wheel-only packages using array for uv build backend ([#595](https://github.com/mkniewallner/migrate-to-uv/pull/595))
 * [poetry] Abort migration for files using `from` in `packages` ([#567](https://github.com/mkniewallner/migrate-to-uv/pull/567))
 * [poetry] Abort migration on `packages` using `from`/`to` and glob ([#615](https://github.com/mkniewallner/migrate-to-uv/pull/615))
+* [poetry] Avoid converting empty `extras` for dependencies ([#624](https://github.com/mkniewallner/migrate-to-uv/pull/624))
 
 ## 0.9.1 - 2025-12-24
 

--- a/src/schema/poetry.rs
+++ b/src/schema/poetry.rs
@@ -113,7 +113,9 @@ impl DependencySpecification {
             } => {
                 let mut pep_508_version = String::new();
 
-                if let Some(extras) = extras {
+                if let Some(extras) = extras
+                    && !extras.is_empty()
+                {
                     pep_508_version.push_str(format!("[{}]", extras.join(", ")).as_str());
                 }
 

--- a/tests/fixtures/poetry/full/pyproject.toml
+++ b/tests/fixtures/poetry/full/pyproject.toml
@@ -109,6 +109,7 @@ pep440 = ">=1.2.3"  # >=1.2.3 (already compliant)
 # Tables
 with-version-only = { version = "1.2.3" }
 with-extras = { version = "1.2.3", extras = ["asyncio", "postgresql_asyncpg"] }
+with-empty-extras = { version = "1.2.3", extras = [] }
 with-markers = { version = "1.2.3", markers = "python_version <= '3.11' or sys_platform == 'win32'" }
 with-platform = { version = "1.2.3", platform = "darwin" }
 with-pipe-delimited-platform = { version = "1.2.3", platform = "darwin|linux" }

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -694,6 +694,7 @@ fn test_skip_lock_full() {
         "pep440>=1.2.3",
         "with-version-only==1.2.3",
         "with-extras[asyncio, postgresql_asyncpg]==1.2.3",
+        "with-empty-extras==1.2.3",
         "with-markers==1.2.3 ; python_version <= '3.11' or sys_platform == 'win32'",
         "with-platform==1.2.3 ; sys_platform == 'darwin'",
         "with-pipe-delimited-platform==1.2.3 ; sys_platform == 'darwin' or sys_platform == 'linux'",


### PR DESCRIPTION
Not a major deal since this is still valid, but in case we have:
```toml
[tool.poetry.dependencies]
foo = { version = "1.2.3", extras = [] }
```

`extras` currently gets converted to an empty array:
```toml
[project]
dependencies = ["foo[]==1.2.3"]
```

This change avoids setting unneeded extra delimiters in that very specific case.