### PR TITLE
fix(poetry): avoid setting empty `module-name` for uv build backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Abort migration for files using `from` in `packages` ([#567](https://github.com/mkniewallner/migrate-to-uv/pull/567))
 * [poetry] Abort migration on `packages` using `from`/`to` and glob ([#615](https://github.com/mkniewallner/migrate-to-uv/pull/615))
 * [poetry] Avoid converting empty `extras` for dependencies ([#624](https://github.com/mkniewallner/migrate-to-uv/pull/624))
+* [poetry] Avoid setting empty `module-name` for uv build backend ([#627](https://github.com/mkniewallner/migrate-to-uv/pull/627))
 
 ## 0.9.1 - 2025-12-24
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Abort migration for files using `from` in `packages` ([#567](https://github.com/mkniewallner/migrate-to-uv/pull/567))
 * [poetry] Abort migration on `packages` using `from`/`to` and glob ([#615](https://github.com/mkniewallner/migrate-to-uv/pull/615))
 * [poetry] Avoid converting empty `extras` for dependencies ([#624](https://github.com/mkniewallner/migrate-to-uv/pull/624))
+* [poetry] Avoid setting empty `module-name` for uv build backend ([#627](https://github.com/mkniewallner/migrate-to-uv/pull/627))
 
 ## 0.9.1 - 2025-12-24
 

--- a/src/converters/poetry/build_backend/uv.rs
+++ b/src/converters/poetry/build_backend/uv.rs
@@ -176,7 +176,11 @@ pub fn get_build_backend(
     }
 
     Ok(Some(UvBuildBackend {
-        module_name: Some(SingleOrVec::Vec(module_name)),
+        module_name: if module_name.is_empty() {
+            None
+        } else {
+            Some(SingleOrVec::Vec(module_name))
+        },
         // By default, uv expects the modules to be in a "src" directory. Since Poetry does not
         // provide a similar option, we want to default to the same thing as Poetry, i.e. an empty
         // string.


### PR DESCRIPTION
Spotted while working on https://github.com/mkniewallner/migrate-to-uv/issues/626.

Setting `module-name = []` means that no module should be included, which is not the same as not setting it, and breaks the auto-discovery that uv does.