### PR TITLE
fix: abort migration on constraints lock failure and revert changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 
 ### Bug fixes
 
+* Abort migration on constraints lock failure and revert changes ([#629](https://github.com/mkniewallner/migrate-to-uv/pull/629))
 * [poetry] Fix typo on `--build-backend` error message ([#571](https://github.com/mkniewallner/migrate-to-uv/pull/571))
 * [poetry] Use `python_full_version` for 3-components Python markers ([#559](https://github.com/mkniewallner/migrate-to-uv/pull/559))
 * [poetry] Handle platform markers delimited by pipe ([#576](https://github.com/mkniewallner/migrate-to-uv/pull/576), [#498](https://github.com/mkniewallner/migrate-to-uv/pull/498))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 
 ### Bug fixes
 
+* Abort migration on constraints lock failure and revert changes ([#629](https://github.com/mkniewallner/migrate-to-uv/pull/629))
 * [poetry] Fix typo on `--build-backend` error message ([#571](https://github.com/mkniewallner/migrate-to-uv/pull/571))
 * [poetry] Use `python_full_version` for 3-components Python markers ([#559](https://github.com/mkniewallner/migrate-to-uv/pull/559))
 * [poetry] Handle platform markers delimited by pipe ([#576](https://github.com/mkniewallner/migrate-to-uv/pull/576), [#498](https://github.com/mkniewallner/migrate-to-uv/pull/498))

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,87 @@
+use crate::common::{apply_filters, cli};
+use dircpy::copy_dir;
+use insta_cmd::assert_cmd_snapshot;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+
+const FIXTURES_PATH: &str = "tests/fixtures";
+
+#[test]
+fn test_revert_changes_no_pyproject() {
+    let fixture_path = Path::new(FIXTURES_PATH).join("pipenv/lock_file_conflicts");
+
+    let tmp_dir = tempdir().unwrap();
+    let project_path = tmp_dir.path();
+
+    copy_dir(fixture_path, project_path).unwrap();
+
+    apply_filters!();
+    assert_cmd_snapshot!(cli().arg(project_path), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Locking dependencies with constraints from existing lock file(s) using "uv lock"...
+    warning: The `requires-python` specifier (`~=3.13`) in `` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
+    Using [PYTHON_INTERPRETER]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there is no version of certifi==2026.1.1 and requests==2.30.0
+          depends on certifi==2026.1.1, we can conclude that requests==2.30.0
+          cannot be used.
+          And because your project depends on requests==2.30.0, we can conclude
+          that your project's requirements are unsatisfiable.
+    error: Could not lock dependencies, aborting the migration. Consider using "--ignore-locked-versions" if you don't need to keep versions from the lock file.
+    "#);
+
+    // Assert that previous package manager files have not been removed.
+    assert!(project_path.join("Pipfile").exists());
+    assert!(project_path.join("Pipfile.lock").exists());
+
+    // Assert that `pyproject.toml` was correctly removed.
+    assert!(!project_path.join("pyproject.toml").exists());
+}
+
+#[test]
+fn test_revert_changes_existing_pyproject() {
+    let fixture_path = Path::new(FIXTURES_PATH).join("pipenv/lock_file_conflicts_with_pyproject");
+
+    let tmp_dir = tempdir().unwrap();
+    let project_path = tmp_dir.path();
+
+    copy_dir(fixture_path, project_path).unwrap();
+
+    let old_pyproject = fs::read_to_string(project_path.join("pyproject.toml")).unwrap();
+
+    apply_filters!();
+    assert_cmd_snapshot!(cli().arg(project_path), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Locking dependencies with constraints from existing lock file(s) using "uv lock"...
+    warning: The `requires-python` specifier (`~=3.13`) in `` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
+    Using [PYTHON_INTERPRETER]
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there is no version of certifi==2026.1.1 and requests==2.30.0
+          depends on certifi==2026.1.1, we can conclude that requests==2.30.0
+          cannot be used.
+          And because your project depends on requests==2.30.0, we can conclude
+          that your project's requirements are unsatisfiable.
+    error: Could not lock dependencies, aborting the migration. Consider using "--ignore-locked-versions" if you don't need to keep versions from the lock file.
+    "#);
+
+    // Assert that previous package manager files have not been removed.
+    assert!(project_path.join("Pipfile").exists());
+    assert!(project_path.join("Pipfile.lock").exists());
+
+    // Assert that `pyproject.toml` has the same content as before the migration.
+    assert_eq!(
+        fs::read_to_string(project_path.join("pyproject.toml")).unwrap(),
+        old_pyproject
+    );
+}

--- a/tests/fixtures/pipenv/lock_file_conflicts/Pipfile
+++ b/tests/fixtures/pipenv/lock_file_conflicts/Pipfile
@@ -1,0 +1,5 @@
+[packages]
+requests = "==2.30"
+
+[requires]
+python_version = "3.13"

--- a/tests/fixtures/pipenv/lock_file_conflicts/Pipfile.lock
+++ b/tests/fixtures/pipenv/lock_file_conflicts/Pipfile.lock
@@ -1,0 +1,28 @@
+{
+    "_meta": {
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.13"
+        }
+    },
+    "default": {
+        "certifi": {
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.1.1"
+        },
+        "charset-normalizer": {
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
+        },
+        "idna": {
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
+        },
+        "requests": {
+            "index": "pip_conf_index_global",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.30.0"
+        }
+    },
+    "develop": {}
+}

--- a/tests/fixtures/pipenv/lock_file_conflicts_with_pyproject/Pipfile
+++ b/tests/fixtures/pipenv/lock_file_conflicts_with_pyproject/Pipfile
@@ -1,0 +1,5 @@
+[packages]
+requests = "==2.30"
+
+[requires]
+python_version = "3.13"

--- a/tests/fixtures/pipenv/lock_file_conflicts_with_pyproject/Pipfile.lock
+++ b/tests/fixtures/pipenv/lock_file_conflicts_with_pyproject/Pipfile.lock
@@ -1,0 +1,28 @@
+{
+    "_meta": {
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.13"
+        }
+    },
+    "default": {
+        "certifi": {
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.1.1"
+        },
+        "charset-normalizer": {
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
+        },
+        "idna": {
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
+        },
+        "requests": {
+            "index": "pip_conf_index_global",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.30.0"
+        }
+    },
+    "develop": {}
+}

--- a/tests/fixtures/pipenv/lock_file_conflicts_with_pyproject/pyproject.toml
+++ b/tests/fixtures/pipenv/lock_file_conflicts_with_pyproject/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.ruff]
+fix = true
+
+[tool.ruff.lint]
+fixable = ["I", "UP"]
+
+[tool.ruff.format]
+preview = true


### PR DESCRIPTION
Closes #608.

If the migration fails when locking dependencies right after adding constraints, we currently leave the project in a bad state, because we still have constraints in `pyproject.toml` that are only meant to be added temporarily.

This changes the behaviour so that we now abort the migration in that case, and revert changes that were done to `pyproject.toml` (if it existed, otherwise we remove the file that was created during the migration). The error message also suggests using [`--ignore-locked-versions`](https://mkniewallner.github.io/migrate-to-uv/configuration/#-ignore-locked-versions), in case the error cannot easily be resolved, or if users did not necessarily care about keeping locked versions.