### PR TITLE
feat(poetry): use more concise warning output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Automatically add Python classifiers for packages based on `python` specifier ([#606](https://github.com/mkniewallner/migrate-to-uv/pull/606))
 * [poetry] Add lower and upper bounds to `uv_build` ([#617](https://github.com/mkniewallner/migrate-to-uv/pull/617))
 * [poetry] Enable namespace for packages without `__init__.py` on uv build backend ([#631](https://github.com/mkniewallner/migrate-to-uv/pull/631))
+* [poetry] Use more concise warnings output ([#632](https://github.com/mkniewallner/migrate-to-uv/pull/632))
 
 ### Bug fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Automatically add Python classifiers for packages based on `python` specifier ([#606](https://github.com/mkniewallner/migrate-to-uv/pull/606))
 * [poetry] Add lower and upper bounds to `uv_build` ([#617](https://github.com/mkniewallner/migrate-to-uv/pull/617))
 * [poetry] Enable namespace for packages without `__init__.py` on uv build backend ([#631](https://github.com/mkniewallner/migrate-to-uv/pull/631))
+* [poetry] Use more concise warnings output ([#632](https://github.com/mkniewallner/migrate-to-uv/pull/632))
 
 ### Bug fixes
 

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -133,15 +133,11 @@ pub trait Converter: Any + Debug {
 
     fn manage_migration_warnings(&self) {
         let migration_errors = MIGRATION_ERRORS.lock().unwrap();
-        let recoverable_errors: Vec<&MigrationError> =
+        let warnings: Vec<&MigrationError> =
             migration_errors.iter().filter(|e| e.recoverable).collect();
 
-        if !recoverable_errors.is_empty() {
-            warn!("The following warnings occurred during the migration:");
-
-            for error in &recoverable_errors {
-                warn!("- {}", error.error);
-            }
+        for warning in &warnings {
+            warn!("{}", warning.error);
         }
     }
 

--- a/src/converters/poetry/build_backend/mod.rs
+++ b/src/converters/poetry/build_backend/mod.rs
@@ -105,7 +105,7 @@ pub fn get_build_backend(
                 Ok(Some(uv)) => Some(BuildBackendObject::Uv(uv)),
                 Err(_) => {
                     add_recoverable_error(
-                        "Migrating build backend to Hatch because package distribution metadata is too complex for uv.".to_string()
+                        "Migrating build backend to Hatch, as package distribution is too complex to be expressed with uv.".to_string()
                     );
 
                     let hatch = hatch::get_build_backend(

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -146,7 +146,7 @@ impl Converter for Poetry {
 
         if let Some(build_backend) = build_backend {
             add_recoverable_error(format!(
-                "Build backend was migrated to {build_backend}. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration."
+                "Build backend was migrated to {build_backend}. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration."
             ));
         }
 

--- a/tests/pip.rs
+++ b/tests/pip.rs
@@ -43,11 +43,10 @@ fn test_complete_workflow() {
     Resolved [PACKAGES] packages in [TIME]
     Successfully migrated project from pip to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
-    warning: - "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
-    warning: - "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
-    warning: - "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
+    warning: "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
+    warning: "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
+    warning: "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
+    warning: "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
     "#);
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -114,11 +113,10 @@ fn test_keep_current_data() {
     Resolved [PACKAGES] packages in [TIME]
     Successfully migrated project from pip to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
-    warning: - "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
-    warning: - "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
-    warning: - "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
+    warning: "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
+    warning: "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
+    warning: "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
+    warning: "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
     "#);
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -178,11 +176,10 @@ fn test_skip_lock() {
     ----- stderr -----
     Successfully migrated project from pip to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
-    warning: - "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
-    warning: - "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
-    warning: - "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
+    warning: "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
+    warning: "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
+    warning: "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
+    warning: "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
     "#);
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -260,11 +257,10 @@ fn test_dry_run() {
     [tool.uv]
     package = false
 
-    warning: The following warnings occurred during the migration:
-    warning: - "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
-    warning: - "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
-    warning: - "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
-    warning: - "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
+    warning: "file:bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:bar".
+    warning: "file:./bar" from "requirements.txt" could not be automatically migrated, try running "uv add file:./bar".
+    warning: "git+https://github.com/psf/requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests".
+    warning: "git+https://github.com/psf/requests#egg=requests" from "requirements.txt" could not be automatically migrated, try running "uv add git+https://github.com/psf/requests#egg=requests".
     "#);
 
     // Assert that previous package manager files have not been removed.

--- a/tests/poetry.rs
+++ b/tests/poetry.rs
@@ -617,10 +617,9 @@ fn test_skip_lock_full() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Migrating build backend to Hatch because package distribution metadata is too complex for uv.
-    warning: - Could not find dependency "non-existing-dependency" listed in "extra-with-non-existing-dependencies" extra.
-    warning: - Build backend was migrated to Hatch. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Migrating build backend to Hatch, as package distribution is too complex to be expressed with uv.
+    warning: Could not find dependency "non-existing-dependency" listed in "extra-with-non-existing-dependencies" extra.
+    warning: Build backend was migrated to Hatch. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     "#);
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -1228,8 +1227,7 @@ fn test_manage_warnings() {
     Resolved [PACKAGES] packages in [TIME]
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Could not find dependency "non-existing-dependency" listed in "extra-with-non-existing-dependencies" extra.
+    warning: Could not find dependency "non-existing-dependency" listed in "extra-with-non-existing-dependencies" extra.
     "#);
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -1392,8 +1390,7 @@ fn test_manage_warnings_dry_run() {
         "typing",
     ]
 
-    warning: The following warnings occurred during the migration:
-    warning: - Could not find dependency "non-existing-dependency" listed in "extra-with-non-existing-dependencies" extra.
+    warning: Could not find dependency "non-existing-dependency" listed in "extra-with-non-existing-dependencies" extra.
     "#);
 
     // Assert that `pyproject.toml` was not updated.
@@ -1438,9 +1435,8 @@ fn test_build_backend_auto_hatch() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Migrating build backend to Hatch because package distribution metadata is too complex for uv.
-    warning: - Build backend was migrated to Hatch. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Migrating build backend to Hatch, as package distribution is too complex to be expressed with uv.
+    warning: Build backend was migrated to Hatch. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -1574,8 +1570,7 @@ fn test_build_backend_auto_uv() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to uv. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to uv. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     apply_filters!();
@@ -1858,8 +1853,7 @@ fn test_build_backend_hatch() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to Hatch. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to Hatch. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
@@ -2067,8 +2061,7 @@ fn test_build_backend_uv() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to uv. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to uv. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     apply_filters!();
@@ -2267,8 +2260,7 @@ fn test_build_backend_implicit_package() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to uv. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to uv. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     apply_filters!();
@@ -2345,8 +2337,7 @@ fn test_build_backend_implicit_package_src() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to uv. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to uv. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     apply_filters!();
@@ -2423,8 +2414,7 @@ fn test_build_backend_implicit_package_src_and_no_src() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to uv. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to uv. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     apply_filters!();
@@ -2501,8 +2491,7 @@ fn test_build_backend_uses_namespace() {
     ----- stderr -----
     Successfully migrated project from Poetry to uv!
 
-    warning: The following warnings occurred during the migration:
-    warning: - Build backend was migrated to uv. It is highly recommended to manually check that files included in the source distribution and wheels are the same than before the migration.
+    warning: Build backend was migrated to uv. It is highly recommended to check that files and data included in the source distribution and wheels are the same after the migration.
     ");
 
     apply_filters!();


### PR DESCRIPTION
The current output for warnings is a bit noisy, especially when the only warning is to recommend checking the source distribution and wheels after the migration.