### PR TITLE
feat: mention `--skip-lock` on lock failure

### DIFF
--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -76,8 +76,9 @@ pub trait Converter: Any + Debug {
             self.revert_changes(had_pyproject, old_pyproject);
 
             error!(
-                "Could not lock dependencies, aborting the migration. Consider using \"{}\" if you don't need to keep versions from the lock file.",
+                "Could not lock dependencies, aborting the migration. Consider using \"{}\" if you don't need to keep versions from the lock file, or \"{}\" if you don't want to lock dependencies at all.",
                 "--ignore-locked-versions".bold(),
+                "--skip-lock".bold(),
             );
             exit(1);
         }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -34,7 +34,7 @@ fn test_revert_changes_no_pyproject() {
           cannot be used.
           And because your project depends on requests==2.30.0, we can conclude
           that your project's requirements are unsatisfiable.
-    error: Could not lock dependencies, aborting the migration. Consider using "--ignore-locked-versions" if you don't need to keep versions from the lock file.
+    error: Could not lock dependencies, aborting the migration. Consider using "--ignore-locked-versions" if you don't need to keep versions from the lock file, or "--skip-lock" if you don't want to lock dependencies at all.
     "#);
 
     // Assert that previous package manager files have not been removed.
@@ -72,7 +72,7 @@ fn test_revert_changes_existing_pyproject() {
           cannot be used.
           And because your project depends on requests==2.30.0, we can conclude
           that your project's requirements are unsatisfiable.
-    error: Could not lock dependencies, aborting the migration. Consider using "--ignore-locked-versions" if you don't need to keep versions from the lock file.
+    error: Could not lock dependencies, aborting the migration. Consider using "--ignore-locked-versions" if you don't need to keep versions from the lock file, or "--skip-lock" if you don't want to lock dependencies at all.
     "#);
 
     // Assert that previous package manager files have not been removed.


### PR DESCRIPTION
Follow-up to #629.

Mention [`--skip-lock`](https://mkniewallner.github.io/migrate-to-uv/configuration/#-skip-lock) as well, since lock failures can come from other things than conflicts (e.g., missing or wrong credentials for private packages).