### PR TITLE
fix(poetry): keep explicit sources when using only one primary/default source with explicit sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* [poetry] Keep explicit sources when using only one primary/default source with explicit sources
+
 ## 0.10.0 - 2026-01-16
 
 ### Breaking changes
@@ -34,7 +40,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Abort migration on `packages` using `from`/`to` and glob ([#615](https://github.com/mkniewallner/migrate-to-uv/pull/615))
 * [poetry] Avoid converting empty `extras` for dependencies ([#624](https://github.com/mkniewallner/migrate-to-uv/pull/624))
 * [poetry] Avoid setting empty `module-name` for uv build backend ([#627](https://github.com/mkniewallner/migrate-to-uv/pull/627))
-* [poetry] handle `src`-layout with empty packages for uv build backend ([#628](https://github.com/mkniewallner/migrate-to-uv/pull/628))
+* [poetry] Handle `src`-layout with empty packages for uv build backend ([#628](https://github.com/mkniewallner/migrate-to-uv/pull/628))
 * [poetry] Sort sources and only set `default` for single `primary`/`default` source ([#633](https://github.com/mkniewallner/migrate-to-uv/pull/633))
 
 ## 0.9.1 - 2025-12-24

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@ icon: lucide/scroll-text
 ---
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+* [poetry] Keep explicit sources when using only one primary/default source with explicit sources
+
 ## 0.10.0 - 2026-01-16
 
 ### Breaking changes
@@ -37,7 +43,7 @@ It is still possible to explicitly choose a specific build backend with `--build
 * [poetry] Abort migration on `packages` using `from`/`to` and glob ([#615](https://github.com/mkniewallner/migrate-to-uv/pull/615))
 * [poetry] Avoid converting empty `extras` for dependencies ([#624](https://github.com/mkniewallner/migrate-to-uv/pull/624))
 * [poetry] Avoid setting empty `module-name` for uv build backend ([#627](https://github.com/mkniewallner/migrate-to-uv/pull/627))
-* [poetry] handle `src`-layout with empty packages for uv build backend ([#628](https://github.com/mkniewallner/migrate-to-uv/pull/628))
+* [poetry] Handle `src`-layout with empty packages for uv build backend ([#628](https://github.com/mkniewallner/migrate-to-uv/pull/628))
 * [poetry] Sort sources and only set `default` for single `primary`/`default` source ([#633](https://github.com/mkniewallner/migrate-to-uv/pull/633))
 
 ## 0.9.1 - 2025-12-24


### PR DESCRIPTION
Closes #661.