### PR TITLE
fix(poetry): correctly set `module-root` when migrating projects without package metadata to uv build backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [poetry] Respect `--build-backend hatch` when migrating projects that have neither `packages` nor `include` nor `exclude` ([#667](https://github.com/mkniewallner/migrate-to-uv/pull/667))
+* [poetry] Correctly set `module-root` when migrating projects without `packages` nor `include` nor `exclude` to uv build backend ([#668](https://github.com/mkniewallner/migrate-to-uv/pull/668))
 
 ## 0.10.1 - 2026-01-26
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ icon: lucide/scroll-text
 ### Bug fixes
 
 * [poetry] Respect `--build-backend hatch` when migrating projects that have neither `packages` nor `include` nor `exclude` ([#667](https://github.com/mkniewallner/migrate-to-uv/pull/667))
+* [poetry] Correctly set `module-root` when migrating projects without `packages` nor `include` nor `exclude` to uv build backend ([#668](https://github.com/mkniewallner/migrate-to-uv/pull/668))
 
 ## 0.10.1 - 2026-01-26
 

--- a/src/converters/poetry/build_backend/mod.rs
+++ b/src/converters/poetry/build_backend/mod.rs
@@ -90,6 +90,7 @@ pub fn get_new_build_system(
 /// Hatch is selected. If `--build-backend` is set to `uv`, Uv is selected.
 pub fn get_build_backend(
     converter_options: &ConverterOptions,
+    build_system: Option<&BuildSystem>,
     poetry: &Poetry,
 ) -> Option<BuildBackendObject> {
     if converter_options.keep_current_build_backend {
@@ -104,6 +105,7 @@ pub fn get_build_backend(
                 poetry.packages.as_ref(),
                 poetry.include.as_ref(),
                 poetry.exclude.as_ref(),
+                build_system,
             );
 
             match uv {
@@ -147,6 +149,7 @@ pub fn get_build_backend(
                 poetry.packages.as_ref(),
                 poetry.include.as_ref(),
                 poetry.exclude.as_ref(),
+                build_system,
             );
 
             match uv {

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -40,7 +40,11 @@ impl Converter for Poetry {
             .poetry
             .unwrap_or_default();
 
-        let build_backend = get_build_backend(&self.converter_options, &poetry);
+        let build_backend = get_build_backend(
+            &self.converter_options,
+            pyproject.build_system.as_ref(),
+            &poetry,
+        );
         let build_system = build_backend::get_new_build_system(
             pyproject.build_system,
             self.converter_options.keep_current_build_backend,


### PR DESCRIPTION
While working on https://github.com/mkniewallner/migrate-to-uv/pull/667, I've noticed that when migrating to uv build backend projects that:
- use neither `packages` nor `include` nor `exclude`
- have a build system
- use a non-src layout where the modules are located in `<project_name>` directory

we are currently not able to properly migrate, because we do not set `module-root = ""` to force uv to use `<project_name>` for the package modules instead of `src/<project_name>`.