### PR TITLE
feat(poetry): bump default `uv_build` bounds to `>=0.10.0,<0.11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* [poetry] Bump default `uv_build` bounds to `>=0.10.0,<0.11.0` ([#683](https://github.com/mkniewallner/migrate-to-uv/pull/683))
+
 ## 0.10.2 - 2026-01-29
 
 ### Bug fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@ icon: lucide/scroll-text
 ---
 # Changelog
 
+## Unreleased
+
+### Features
+
+* [poetry] Bump default `uv_build` bounds to `>=0.10.0,<0.11.0` ([#683](https://github.com/mkniewallner/migrate-to-uv/pull/683))
+
 ## 0.10.2 - 2026-01-29
 
 ### Bug fixes

--- a/src/converters/poetry/build_backend/mod.rs
+++ b/src/converters/poetry/build_backend/mod.rs
@@ -19,7 +19,7 @@ pub mod uv;
 /// backend (<https://github.com/astral-sh/uv/releases/tag/0.7.19>).
 const MIN_UV_BUILD_VERSION: &str = "0.7.19";
 /// Default bounds to use for `uv_build` when no version is found.
-const UV_BUILD_DEFAULT_BOUNDS: &str = ">=0.9.0,<0.10.0";
+const UV_BUILD_DEFAULT_BOUNDS: &str = ">=0.10.0,<0.11.0";
 
 pub enum BuildBackendObject {
     Uv(UvBuildBackend),


### PR DESCRIPTION
Update default `uv_build` bounds to account for [0.10.0](https://github.com/astral-sh/uv/releases/tag/0.10.0) release.