### PR TITLE
test: remove `UV_NO_CACHE` to speed up tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test-unit:
 .PHONY: test-integration
 test-integration:
 	# Disable parallelism as this causes concurrency issues on Windows when uv cache is accessed.
-	UV_NO_CACHE=1 cargo test --test '*' -- --test-threads 1
+	cargo test --test '*' -- --test-threads 1
 
 .PHONY: test
 test: test-unit test-integration


### PR DESCRIPTION
This was initially added for reproducibility on the `uv lock` phase of integration tests, but it looks like we're fine even without it.

This will greatly speed up integration tests, especially on Windows ([~4m42s](https://github.com/mkniewallner/migrate-to-uv/actions/runs/22024547529/job/63638994229) vs. [~2m1s](https://github.com/mkniewallner/migrate-to-uv/actions/runs/22035051499/job/63666422504?pr=703) when removing `UV_NO_CACHE`).

If we find issues with reproducibility, we can always add filters to insta.