### PR TITLE
feat: add `set-default-groups-all` option to `--dependency-groups-strategy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* Add `set-default-groups-all` option to `--dependency-groups-strategy` ([#708](https://github.com/mkniewallner/migrate-to-uv/pull/708))
 * Add `--ignore-errors` flag to perform the migration even in case of errors ([#657](https://github.com/mkniewallner/migrate-to-uv/pull/657))
 * [poetry] Bump default `uv_build` bounds to `>=0.10.0,<0.11.0` ([#683](https://github.com/mkniewallner/migrate-to-uv/pull/683))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ icon: lucide/scroll-text
 
 ### Features
 
+* Add `set-default-groups-all` option to `--dependency-groups-strategy` ([#708](https://github.com/mkniewallner/migrate-to-uv/pull/708))
 * Add `--ignore-errors` flag to perform the migration even in case of errors ([#657](https://github.com/mkniewallner/migrate-to-uv/pull/657))
 * [poetry] Bump default `uv_build` bounds to `>=0.10.0,<0.11.0` ([#683](https://github.com/mkniewallner/migrate-to-uv/pull/683))
 

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -2,6 +2,7 @@ use crate::converters::pyproject_updater::PyprojectUpdater;
 use crate::errors::{MIGRATION_ERRORS, MigrationError};
 use crate::schema::pep_621::Project;
 use crate::schema::pyproject::DependencyGroupSpecification;
+use crate::schema::utils::SingleOrVec;
 use crate::uv;
 use crate::uv::LockType;
 use indexmap::IndexMap;
@@ -23,7 +24,7 @@ mod pyproject_updater;
 
 type DependencyGroupsAndDefaultGroups = (
     Option<IndexMap<String, Vec<DependencyGroupSpecification>>>,
-    Option<Vec<String>>,
+    Option<SingleOrVec<String>>,
 );
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -337,6 +338,7 @@ pub trait Converter: Any + Debug {
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum DependencyGroupsStrategy {
     #[default]
+    SetDefaultGroupsAll,
     SetDefaultGroups,
     IncludeInDev,
     KeepExisting,

--- a/src/schema/uv.rs
+++ b/src/schema/uv.rs
@@ -11,7 +11,7 @@ pub struct Uv {
     pub sources: Option<IndexMap<String, SourceContainer>>,
     /// <https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups>
     #[serde(rename = "default-groups")]
-    pub default_groups: Option<Vec<String>>,
+    pub default_groups: Option<SingleOrVec<String>>,
     #[serde(rename = "constraint-dependencies")]
     pub constraint_dependencies: Option<Vec<String>>,
     #[serde(rename = "build-backend")]

--- a/tests/pipenv.rs
+++ b/tests/pipenv.rs
@@ -240,6 +240,117 @@ fn test_keep_current_data() {
 }
 
 #[test]
+fn test_dependency_groups_strategy_set_default_groups_all() {
+    let fixture_path = Path::new(FIXTURES_PATH).join("with_lock_file");
+
+    let tmp_dir = tempdir().unwrap();
+    let project_path = tmp_dir.path();
+
+    copy_dir(fixture_path, project_path).unwrap();
+
+    apply_filters!();
+    assert_cmd_snapshot!(cli()
+        .arg(project_path)
+        .arg("--dependency-groups-strategy")
+        .arg("set-default-groups-all"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Locking dependencies with constraints from existing lock file(s) using "uv lock"...
+    Using [PYTHON_INTERPRETER]
+    warning: No `requires-python` value found in the workspace. Defaulting to `[PYTHON_VERSION]`.
+    Resolved [PACKAGES] packages in [TIME]
+    Locking dependencies again using "uv lock" to remove constraints...
+    Using [PYTHON_INTERPRETER]
+    warning: No `requires-python` value found in the workspace. Defaulting to `[PYTHON_VERSION]`.
+    Resolved [PACKAGES] packages in [TIME]
+    Successfully migrated project from Pipenv to uv!
+    "#);
+
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
+    [project]
+    name = ""
+    version = "0.0.1"
+    dependencies = ["arrow>=1.2.3"]
+
+    [dependency-groups]
+    dev = ["mypy>=1.13.0"]
+    test = ["factory-boy>=3.2.1"]
+
+    [tool.uv]
+    package = false
+    default-groups = "all"
+
+    [[tool.uv.index]]
+    name = "pypi"
+    url = "https://pypi.org/simple"
+    "#);
+
+    // Assert that previous package manager files are correctly removed.
+    assert!(!project_path.join("Pipfile").exists());
+    assert!(!project_path.join("Pipfile.lock").exists());
+}
+
+#[test]
+fn test_dependency_groups_strategy_set_default_groups() {
+    let fixture_path = Path::new(FIXTURES_PATH).join("with_lock_file");
+
+    let tmp_dir = tempdir().unwrap();
+    let project_path = tmp_dir.path();
+
+    copy_dir(fixture_path, project_path).unwrap();
+
+    apply_filters!();
+    assert_cmd_snapshot!(cli()
+        .arg(project_path)
+        .arg("--dependency-groups-strategy")
+        .arg("set-default-groups"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Locking dependencies with constraints from existing lock file(s) using "uv lock"...
+    Using [PYTHON_INTERPRETER]
+    warning: No `requires-python` value found in the workspace. Defaulting to `[PYTHON_VERSION]`.
+    Resolved [PACKAGES] packages in [TIME]
+    Locking dependencies again using "uv lock" to remove constraints...
+    Using [PYTHON_INTERPRETER]
+    warning: No `requires-python` value found in the workspace. Defaulting to `[PYTHON_VERSION]`.
+    Resolved [PACKAGES] packages in [TIME]
+    Successfully migrated project from Pipenv to uv!
+    "#);
+
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
+    [project]
+    name = ""
+    version = "0.0.1"
+    dependencies = ["arrow>=1.2.3"]
+
+    [dependency-groups]
+    dev = ["mypy>=1.13.0"]
+    test = ["factory-boy>=3.2.1"]
+
+    [tool.uv]
+    package = false
+    default-groups = [
+        "dev",
+        "test",
+    ]
+
+    [[tool.uv.index]]
+    name = "pypi"
+    url = "https://pypi.org/simple"
+    "#);
+
+    // Assert that previous package manager files are correctly removed.
+    assert!(!project_path.join("Pipfile").exists());
+    assert!(!project_path.join("Pipfile.lock").exists());
+}
+
+#[test]
 fn test_dependency_groups_strategy_include_in_dev() {
     let fixture_path = Path::new(FIXTURES_PATH).join("with_lock_file");
 


### PR DESCRIPTION
First step of https://github.com/mkniewallner/migrate-to-uv/issues/702 that adds a way to set [`default-groups = "all"`](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups).