### PR TITLE
fix: default to "project" as project name when not inferable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [poetry] Bump default `uv_build` bounds to `>=0.12.0,<0.13` ([#921](https://github.com/osprey-oss/migrate-to-uv/pull/921))
 
+### Bug fixes
+
+* Default to "project" as project name when not inferable ([#922](https://github.com/osprey-oss/migrate-to-uv/pull/922))
+
 ## 0.12.0 - 2026-04-08
 
 The project source code was moved under [a new GitHub organization](https://github.com/osprey-oss/migrate-to-uv). This release does not come with functional changes, but since the documentation has been moved to a [new URL](https://osprey-oss.github.io/migrate-to-uv/), it ensures that links are updated in the CLI and in PyPI metadata. See https://github.com/osprey-oss/migrate-to-uv/issues/823 for details about the move to an organization.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ icon: lucide/scroll-text
 
 * [poetry] Bump default `uv_build` bounds to `>=0.12.0,<0.13` ([#921](https://github.com/osprey-oss/migrate-to-uv/pull/921))
 
+### Bug fixes
+
+* Default to "project" as project name when not inferable ([#922](https://github.com/osprey-oss/migrate-to-uv/pull/922))
+
 ## 0.12.0 - 2026-04-08
 
 The project source code was moved under [a new GitHub organization](https://github.com/osprey-oss/migrate-to-uv). This release does not come with functional changes, but since the documentation has been moved to a [new URL](https://osprey-oss.github.io/migrate-to-uv/), it ensures that links are updated in the CLI and in PyPI metadata. See https://github.com/osprey-oss/migrate-to-uv/issues/823 for details about the move to an organization.

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -27,6 +27,9 @@ type DependencyGroupsAndDefaultGroups = (
     Option<SingleOrVec<String>>,
 );
 
+// Default project name to use in `[project.name]` when it couldn't be determined.
+const DEFAULT_PROJECT_NAME: &str = "project";
+
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ConverterOptions {

--- a/src/converters/pip/mod.rs
+++ b/src/converters/pip/mod.rs
@@ -1,8 +1,8 @@
 mod dependencies;
 
-use crate::converters::Converter;
 use crate::converters::ConverterOptions;
 use crate::converters::pyproject_updater::PyprojectUpdater;
+use crate::converters::{Converter, DEFAULT_PROJECT_NAME};
 use crate::schema::pep_621::Project;
 use crate::schema::pyproject::{DependencyGroupSpecification, PyProject};
 use crate::schema::uv::Uv;
@@ -43,8 +43,8 @@ impl Converter for Pip {
         });
 
         let project = Project {
-            // "name" is required by uv.
-            name: Some(String::new()),
+            // "name" is required by uv, and must not be empty.
+            name: Some(DEFAULT_PROJECT_NAME.to_string()),
             dependencies: dependencies::get(
                 &self.get_project_path(),
                 self.requirements_files.clone(),
@@ -183,15 +183,15 @@ mod tests {
             is_pip_tools: false,
         };
 
-        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         dependencies = ["foo==1.2.3"]
         dynamic = ["version"]
 
         [tool.uv]
         package = false
-        "###);
+        "#);
     }
 
     #[test]
@@ -230,14 +230,14 @@ mod tests {
             is_pip_tools: false,
         };
 
-        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
         [tool.uv]
         package = false
-        "###);
+        "#);
     }
 }

--- a/src/converters/pipenv/mod.rs
+++ b/src/converters/pipenv/mod.rs
@@ -2,9 +2,9 @@ mod dependencies;
 mod project;
 mod sources;
 
-use crate::converters::Converter;
 use crate::converters::ConverterOptions;
 use crate::converters::pyproject_updater::PyprojectUpdater;
+use crate::converters::{Converter, DEFAULT_PROJECT_NAME};
 use crate::errors::add_recoverable_error;
 use crate::schema::pep_621::Project;
 use crate::schema::pipenv::{PipenvLock, Pipfile};
@@ -41,8 +41,8 @@ impl Converter for Pipenv {
             );
 
         let project = Project {
-            // "name" is required by uv.
-            name: Some(String::new()),
+            // "name" is required by uv, and must not be empty.
+            name: Some(DEFAULT_PROJECT_NAME.to_string()),
             requires_python: project::get_requires_python(pipfile.requires),
             dependencies: dependencies::get(pipfile.packages.as_ref(), &mut uv_source_index),
             ..Default::default()
@@ -159,15 +159,15 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = "==3.13.1"
 
         [tool.uv]
         package = false
-        "###);
+        "#);
     }
 
     #[test]
@@ -190,14 +190,14 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
 
         [tool.uv]
         package = false
-        "###);
+        "#);
     }
 
     #[test]
@@ -234,15 +234,15 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         dependencies = ["foo==1.2.3"]
         dynamic = ["version"]
 
         [tool.uv]
         package = false
-        "###);
+        "#);
     }
 
     #[test]
@@ -279,15 +279,15 @@ mod tests {
             },
         };
 
-        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r###"
+        insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
         [tool.uv]
         package = false
-        "###);
+        "#);
     }
 
     #[test]
@@ -322,7 +322,7 @@ foobar = "1.2.3"
 
         insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
@@ -367,7 +367,7 @@ foobar = "1.2.3"
 
         insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
@@ -413,7 +413,7 @@ foobar = "1.2.3"
 
         insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
@@ -462,7 +462,7 @@ foobar = "1.2.3"
 
         insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
@@ -510,7 +510,7 @@ foobar = "1.2.3"
 
         insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 
@@ -555,7 +555,7 @@ foobar = "1.2.3"
 
         insta::assert_snapshot!(pipenv.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         dependencies = ["foo==1.2.3"]
 

--- a/src/converters/poetry/mod.rs
+++ b/src/converters/poetry/mod.rs
@@ -4,11 +4,11 @@ mod project;
 mod sources;
 pub mod version;
 
-use crate::converters::Converter;
 use crate::converters::ConverterOptions;
 use crate::converters::poetry::build_backend::{BuildBackendObject, get_build_backend};
 use crate::converters::poetry::project::get_classifiers;
 use crate::converters::pyproject_updater::PyprojectUpdater;
+use crate::converters::{Converter, DEFAULT_PROJECT_NAME};
 use crate::errors::{
     MIGRATION_ERRORS, MigrationError, add_recoverable_error, add_unrecoverable_error,
 };
@@ -85,8 +85,8 @@ impl Converter for Poetry {
             .and_then(|plugins| plugins.shift_remove("gui_scripts"));
 
         let project = Project {
-            // "name" is required by uv.
-            name: Some(poetry.name.unwrap_or_default()),
+            // "name" is required by uv, and must not be empty.
+            name: Some(poetry.name.unwrap_or(DEFAULT_PROJECT_NAME.to_string())),
             description: poetry.description,
             authors: project::get_authors(poetry.authors),
             requires_python: requires_python.clone(),
@@ -295,7 +295,7 @@ mod tests {
 
         insta::assert_snapshot!(poetry.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         "#);
     }
@@ -330,7 +330,7 @@ mod tests {
 
         insta::assert_snapshot!(poetry.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=3.12,<4"
         license = { text = "MIT" }
@@ -367,7 +367,7 @@ mod tests {
 
         insta::assert_snapshot!(poetry.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=3.12,<4"
         license = { file = "LICENSE" }
@@ -551,7 +551,7 @@ build-backend = "poetry.core.masonry.api"
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         classifiers = [
             "Programming Language :: Python :: 2",
@@ -608,7 +608,7 @@ python = "^3.10"
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=3.10,<4"
         classifiers = [
@@ -658,7 +658,7 @@ python = ">=3.2,<3.13"
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=3.2,<3.13"
         classifiers = [
@@ -712,7 +712,7 @@ python = ">=2.6"
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=2.6"
         classifiers = [
@@ -778,7 +778,7 @@ python = ">=3.10"
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=3.10"
         classifiers = [
@@ -854,7 +854,7 @@ build-backend = "bar"
 
         insta::assert_snapshot!(poetry.build_uv_pyproject(), @r#"
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
 
 
@@ -957,7 +957,7 @@ requires-python = ">=3.10"
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         requires-python = ">=3.10"
         classifiers = [
@@ -1012,7 +1012,7 @@ classifiers = [
         build-backend = "uv_build"
 
         [project]
-        name = ""
+        name = "project"
         version = "0.0.1"
         classifiers = [
             "Intended Audience :: Developers",

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -26,7 +26,7 @@ fn test_revert_changes_no_pyproject() {
 
     ----- stderr -----
     Locking dependencies with constraints from existing lock file(s) using "uv lock"...
-    warning: The `requires-python` specifier (`~=3.13`) in `` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
+    warning: The `requires-python` specifier (`~=3.13`) in `project` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
     Using [PYTHON_INTERPRETER]
       × No solution found when resolving dependencies:
       ╰─▶ Because there is no version of certifi==2026.1.1 and requests==2.30.0
@@ -64,7 +64,7 @@ fn test_revert_changes_existing_pyproject() {
 
     ----- stderr -----
     Locking dependencies with constraints from existing lock file(s) using "uv lock"...
-    warning: The `requires-python` specifier (`~=3.13`) in `` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
+    warning: The `requires-python` specifier (`~=3.13`) in `project` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
     Using [PYTHON_INTERPRETER]
       × No solution found when resolving dependencies:
       ╰─▶ Because there is no version of certifi==2026.1.1 and requests==2.30.0

--- a/tests/pip.rs
+++ b/tests/pip.rs
@@ -51,7 +51,7 @@ fn test_complete_workflow() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = [
         "arrow==1.3.0",
@@ -123,7 +123,7 @@ fn test_keep_current_data() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = [
         "arrow==1.3.0",
@@ -188,7 +188,7 @@ fn test_skip_lock() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = [
         "arrow==1.3.0",
@@ -243,7 +243,7 @@ fn test_dry_run() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = [
         "arrow==1.3.0",
@@ -316,7 +316,7 @@ fn test_replaces_existing_project() {
     assert_cmd_snapshot!(cli()
         .arg(&project_path)
         .arg("--dry-run")
-        .arg("--replace-project-section"), @r###"
+        .arg("--replace-project-section"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -324,7 +324,7 @@ fn test_replaces_existing_project() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = [
         "arrow==1.3.0",
@@ -334,5 +334,5 @@ fn test_replaces_existing_project() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 }

--- a/tests/pip_tools.rs
+++ b/tests/pip_tools.rs
@@ -49,9 +49,9 @@ fn test_complete_workflow() {
     Successfully migrated project from pip-tools to uv!
     "#);
 
-    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r###"
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -63,7 +63,7 @@ fn test_complete_workflow() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     let uv_lock = toml::from_str::<UvLock>(
         fs::read_to_string(project_path.join("uv.lock"))
@@ -76,7 +76,7 @@ fn test_complete_workflow() {
     let uv_lock_packages = uv_lock.package.unwrap();
     let expected_locked_packages = Vec::from([
         LockedPackage {
-            name: String::new(),
+            name: "project".to_string(),
             version: "0.0.1".to_string(),
         },
         LockedPackage {
@@ -159,9 +159,9 @@ fn test_ignore_locked_versions() {
     Successfully migrated project from pip-tools to uv!
     "#);
 
-    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r###"
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -173,7 +173,7 @@ fn test_ignore_locked_versions() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     let uv_lock = toml::from_str::<UvLock>(
         fs::read_to_string(project_path.join("uv.lock"))
@@ -243,9 +243,9 @@ fn test_keep_current_data() {
     Successfully migrated project from pip-tools to uv!
     "#);
 
-    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r###"
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -257,7 +257,7 @@ fn test_keep_current_data() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     // Assert that previous package manager files have not been removed.
     for file in requirements_files {
@@ -297,9 +297,9 @@ fn test_skip_lock() {
     Successfully migrated project from pip-tools to uv!
     "###);
 
-    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r###"
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -311,7 +311,7 @@ fn test_skip_lock() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     // Assert that previous package manager files are correctly removed.
     for file in requirements_files {
@@ -354,9 +354,9 @@ fn test_skip_lock_full() {
     Successfully migrated project from pip-tools to uv!
     "###);
 
-    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r###"
+    insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = [
         "arrow",
@@ -374,7 +374,7 @@ fn test_skip_lock_full() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     // Assert that previous package manager files are correctly removed.
     for file in requirements_files {
@@ -403,7 +403,7 @@ fn test_dry_run() {
         .arg("requirements-dev.in")
         .arg("--dev-requirements-file")
         .arg("requirements-typing.in")
-        .arg("--dry-run"), @r###"
+        .arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -411,7 +411,7 @@ fn test_dry_run() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -423,7 +423,7 @@ fn test_dry_run() {
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     // Assert that previous package manager files have not been removed.
     for file in requirements_files {
@@ -466,7 +466,7 @@ fn test_replaces_existing_project() {
     assert_cmd_snapshot!(cli()
         .arg(&project_path)
         .arg("--dry-run")
-        .arg("--replace-project-section"), @r###"
+        .arg("--replace-project-section"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -474,11 +474,11 @@ fn test_replaces_existing_project() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 }

--- a/tests/pipenv.rs
+++ b/tests/pipenv.rs
@@ -38,7 +38,7 @@ fn test_complete_workflow() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -66,7 +66,7 @@ fn test_complete_workflow() {
     let uv_lock_packages = uv_lock.package.unwrap();
     let expected_locked_packages = Vec::from([
         LockedPackage {
-            name: String::new(),
+            name: "project".to_string(),
             version: "0.0.1".to_string(),
         },
         LockedPackage {
@@ -136,7 +136,7 @@ fn test_ignore_locked_versions() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -208,7 +208,7 @@ fn test_keep_current_data() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -250,7 +250,7 @@ fn test_skip_lock() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -295,7 +295,7 @@ fn test_skip_lock_full() {
 
     insta::assert_snapshot!(fs::read_to_string(project_path.join("pyproject.toml")).unwrap(), @r#"
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     requires-python = "~=3.13"
     dependencies = [
@@ -384,7 +384,7 @@ fn test_dry_run() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     dependencies = ["arrow>=1.2.3"]
 
@@ -416,7 +416,7 @@ fn test_dry_run() {
 fn test_dry_run_minimal() {
     let project_path = Path::new(FIXTURES_PATH).join("minimal");
 
-    assert_cmd_snapshot!(cli().arg(&project_path).arg("--dry-run"), @r###"
+    assert_cmd_snapshot!(cli().arg(&project_path).arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -424,12 +424,12 @@ fn test_dry_run_minimal() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
 
     [tool.uv]
     package = false
-    "###);
+    "#);
 
     // Assert that previous package manager files have not been removed.
     assert!(project_path.join("Pipfile").exists());
@@ -487,7 +487,7 @@ fn test_replaces_existing_project() {
     ----- stderr -----
     Migrated pyproject.toml:
     [project]
-    name = ""
+    name = "project"
     version = "0.0.1"
     requires-python = "~=3.13"
     dependencies = ["arrow>=1.2.3"]


### PR DESCRIPTION
As highlighted in https://github.com/osprey-oss/migrate-to-uv/pull/882, since uv [0.11.15](https://github.com/astral-sh/uv/releases/tag/0.11.15), an empty project name now leads to an error.

Since it's not easy to infer the project name when nothing was originally set (e.g., for pip, pip-tools or pipenv), we now default to using "project" instead of an empty string, as it's better than ending up with a failure during the migration, or an invalid project if not locking during the migration.